### PR TITLE
Update dependencies versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "herdphp/phpsp.org.br",
   "require": {
-    "tightenco/jigsaw": "^1.0"
+    "tightenco/jigsaw": "^v1.3.6"
   },
   "autoload": {
     "psr-4": {
@@ -12,5 +12,8 @@
       "name": "Joao Paulo Vendramini Martins",
       "email": "jp.joao@gmail.com"
     }
-  ]
+  ],
+  "require-dev": {
+    "malukenho/mcbumpface": "^0.1.3"
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2221937584b4e0975d3b3a078efccf92",
+    "content-hash": "d53ae8558df6dc2baf26750c27e2a456",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -213,16 +213,16 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v5.7.9",
+            "version": "v5.7.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
-                "reference": "73cde7bd4985eefb1d468a745e1d50d03e276121"
+                "reference": "53a0991e918efaace42cde526a04fdb832128a03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/container/zipball/73cde7bd4985eefb1d468a745e1d50d03e276121",
-                "reference": "73cde7bd4985eefb1d468a745e1d50d03e276121",
+                "url": "https://api.github.com/repos/illuminate/container/zipball/53a0991e918efaace42cde526a04fdb832128a03",
+                "reference": "53a0991e918efaace42cde526a04fdb832128a03",
                 "shasum": ""
             },
             "require": {
@@ -254,20 +254,20 @@
             ],
             "description": "The Illuminate Container package.",
             "homepage": "https://laravel.com",
-            "time": "2018-10-07T15:52:17+00:00"
+            "time": "2018-12-18T14:00:02+00:00"
         },
         {
             "name": "illuminate/contracts",
-            "version": "v5.7.9",
+            "version": "v5.7.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "64df81d3382d876f1c1d3d5481d89c93b61b8279"
+                "reference": "3d67e2d7c9087ae3a2a53d9b102697e5f482d6d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/64df81d3382d876f1c1d3d5481d89c93b61b8279",
-                "reference": "64df81d3382d876f1c1d3d5481d89c93b61b8279",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/3d67e2d7c9087ae3a2a53d9b102697e5f482d6d0",
+                "reference": "3d67e2d7c9087ae3a2a53d9b102697e5f482d6d0",
                 "shasum": ""
             },
             "require": {
@@ -298,11 +298,11 @@
             ],
             "description": "The Illuminate Contracts package.",
             "homepage": "https://laravel.com",
-            "time": "2018-10-08T13:34:14+00:00"
+            "time": "2019-01-09T10:34:49+00:00"
         },
         {
             "name": "illuminate/events",
-            "version": "v5.7.9",
+            "version": "v5.7.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -347,16 +347,16 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v5.7.9",
+            "version": "v5.7.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "a09fae4470494dc9867609221b46fe844f2f3b70"
+                "reference": "19ba2ac5f85b7505d7c2bf6307d10633f9f3c6b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/a09fae4470494dc9867609221b46fe844f2f3b70",
-                "reference": "a09fae4470494dc9867609221b46fe844f2f3b70",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/19ba2ac5f85b7505d7c2bf6307d10633f9f3c6b0",
+                "reference": "19ba2ac5f85b7505d7c2bf6307d10633f9f3c6b0",
                 "shasum": ""
             },
             "require": {
@@ -395,20 +395,20 @@
             ],
             "description": "The Illuminate Filesystem package.",
             "homepage": "https://laravel.com",
-            "time": "2018-08-14T19:42:44+00:00"
+            "time": "2018-12-28T14:33:29+00:00"
         },
         {
             "name": "illuminate/support",
-            "version": "v5.7.9",
+            "version": "v5.7.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "ea95697233b06650382eb0f5798be22b4e520dea"
+                "reference": "ea3f30dd824bba52bcff4290dc7431b0ffb478e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/ea95697233b06650382eb0f5798be22b4e520dea",
-                "reference": "ea95697233b06650382eb0f5798be22b4e520dea",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/ea3f30dd824bba52bcff4290dc7431b0ffb478e1",
+                "reference": "ea3f30dd824bba52bcff4290dc7431b0ffb478e1",
                 "shasum": ""
             },
             "require": {
@@ -454,20 +454,20 @@
             ],
             "description": "The Illuminate Support package.",
             "homepage": "https://laravel.com",
-            "time": "2018-10-07T15:51:39+00:00"
+            "time": "2019-01-07T13:39:07+00:00"
         },
         {
             "name": "illuminate/view",
-            "version": "v5.7.9",
+            "version": "v5.7.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",
-                "reference": "040b1a85d12eeae0335cb06827de4fd2fdcb5b51"
+                "reference": "87755dad0c47a4afa050d0cc7da39d582e4b4ae4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/view/zipball/040b1a85d12eeae0335cb06827de4fd2fdcb5b51",
-                "reference": "040b1a85d12eeae0335cb06827de4fd2fdcb5b51",
+                "url": "https://api.github.com/repos/illuminate/view/zipball/87755dad0c47a4afa050d0cc7da39d582e4b4ae4",
+                "reference": "87755dad0c47a4afa050d0cc7da39d582e4b4ae4",
                 "shasum": ""
             },
             "require": {
@@ -502,7 +502,7 @@
             ],
             "description": "The Illuminate View package.",
             "homepage": "https://laravel.com",
-            "time": "2018-10-06T18:48:42+00:00"
+            "time": "2018-11-02T14:57:34+00:00"
         },
         {
             "name": "mnapoli/front-yaml",
@@ -606,16 +606,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "1.34.0",
+            "version": "1.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "1dbd3cb01c5645f3e7deda7aa46ef780d95fcc33"
+                "reference": "cd324b98bc30290f233dd0e75e6ce49f7ab2a6c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/1dbd3cb01c5645f3e7deda7aa46ef780d95fcc33",
-                "reference": "1dbd3cb01c5645f3e7deda7aa46ef780d95fcc33",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/cd324b98bc30290f233dd0e75e6ce49f7ab2a6c9",
+                "reference": "cd324b98bc30290f233dd0e75e6ce49f7ab2a6c9",
                 "shasum": ""
             },
             "require": {
@@ -623,8 +623,11 @@
                 "symfony/translation": "~2.6 || ~3.0 || ~4.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7"
+            },
+            "suggest": {
+                "friendsofphp/php-cs-fixer": "Needed for the `composer phpcs` command. Allow to automatically fix code style.",
+                "phpstan/phpstan": "Needed for the `composer phpstan` command. Allow to detect potential errors."
             },
             "type": "library",
             "extra": {
@@ -657,7 +660,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2018-09-20T19:36:25+00:00"
+            "time": "2018-12-28T10:07:33+00:00"
         },
         {
             "name": "psr/container",
@@ -710,16 +713,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -753,7 +756,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -805,25 +808,29 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.1.6",
+            "version": "v4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "dc7122fe5f6113cfaba3b3de575d31112c9aa60b"
+                "reference": "1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/dc7122fe5f6113cfaba3b3de575d31112c9aa60b",
-                "reference": "dc7122fe5f6113cfaba3b3de575d31112c9aa60b",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4",
+                "reference": "1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
+                "symfony/contracts": "^1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
                 "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
@@ -834,7 +841,7 @@
                 "symfony/process": "~3.4|~4.0"
             },
             "suggest": {
-                "psr/log-implementation": "For using the console logger",
+                "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -842,7 +849,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -869,20 +876,88 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-03T08:15:46+00:00"
+            "time": "2019-01-25T14:35:16+00:00"
         },
         {
-            "name": "symfony/debug",
-            "version": "v4.1.6",
+            "name": "symfony/contracts",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "e3f76ce6198f81994e019bb2b4e533e9de1b9b90"
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e3f76ce6198f81994e019bb2b4e533e9de1b9b90",
-                "reference": "e3f76ce6198f81994e019bb2b4e533e9de1b9b90",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2018-12-05T08:06:11+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "cf9b2e33f757deb884ce474e06d2647c1c769b65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/cf9b2e33f757deb884ce474e06d2647c1c769b65",
+                "reference": "cf9b2e33f757deb884ce474e06d2647c1c769b65",
                 "shasum": ""
             },
             "require": {
@@ -898,7 +973,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -925,20 +1000,77 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:36:10+00:00"
+            "time": "2019-01-25T14:35:16+00:00"
         },
         {
-            "name": "symfony/finder",
-            "version": "v4.1.6",
+            "name": "symfony/dotenv",
+            "version": "v4.2.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "1f17195b44543017a9c9b2d437c670627e96ad06"
+                "url": "https://github.com/symfony/dotenv.git",
+                "reference": "9a3bdfcd7a0d9602754894d76c614d15ca366535"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/1f17195b44543017a9c9b2d437c670627e96ad06",
-                "reference": "1f17195b44543017a9c9b2d437c670627e96ad06",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/9a3bdfcd7a0d9602754894d76c614d15ca366535",
+                "reference": "9a3bdfcd7a0d9602754894d76c614d15ca366535",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "symfony/process": "~3.4|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Dotenv\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Registers environment variables from a .env file",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "time": "2019-01-24T21:39:51+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "ef71816cbb264988bb57fe6a73f610888b9aa70c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ef71816cbb264988bb57fe6a73f610888b9aa70c",
+                "reference": "ef71816cbb264988bb57fe6a73f610888b9aa70c",
                 "shasum": ""
             },
             "require": {
@@ -947,7 +1079,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -974,11 +1106,11 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-03T08:47:56+00:00"
+            "time": "2019-01-16T20:35:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -1036,16 +1168,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
                 "shasum": ""
             },
             "require": {
@@ -1091,30 +1223,138 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2018-09-21T13:07:52+00:00"
         },
         {
-            "name": "symfony/translation",
-            "version": "v4.1.6",
+            "name": "symfony/polyfill-php72",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "9f0b61e339160a466ebcde167a6c5521c810e304"
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/9f0b61e339160a466ebcde167a6c5521c810e304",
-                "reference": "9f0b61e339160a466ebcde167a6c5521c810e304",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
+                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-09-21T13:07:52+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "6c05edb11fbeff9e2b324b4270ecb17911a8b7ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/6c05edb11fbeff9e2b324b4270ecb17911a8b7ad",
+                "reference": "6c05edb11fbeff9e2b324b4270ecb17911a8b7ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-24T22:05:03+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "23fd7aac70d99a17a8e6473a41fec8fab3331050"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/23fd7aac70d99a17a8e6473a41fec8fab3331050",
+                "reference": "23fd7aac70d99a17a8e6473a41fec8fab3331050",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
+                "symfony/contracts": "^1.0.2",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/config": "<3.4",
                 "symfony/dependency-injection": "<3.4",
                 "symfony/yaml": "<3.4"
+            },
+            "provide": {
+                "symfony/translation-contracts-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
@@ -1133,7 +1373,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1160,20 +1400,96 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:36:10+00:00"
+            "time": "2019-01-27T23:11:39+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v4.1.6",
+            "name": "symfony/var-dumper",
+            "version": "v4.2.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9"
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "223bda89f9be41cf7033eeaf11bc61a280489c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/367e689b2fdc19965be435337b50bc8adf2746c9",
-                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/223bda89f9be41cf7033eeaf11bc61a280489c17",
+                "reference": "223bda89f9be41cf7033eeaf11bc61a280489c17",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php72": "~1.5"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0",
+                "twig/twig": "~1.34|~2.4"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2019-01-30T11:44:30+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d461670ee145092b7e2a56c1da7118f19cadadb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d461670ee145092b7e2a56c1da7118f19cadadb0",
+                "reference": "d461670ee145092b7e2a56c1da7118f19cadadb0",
                 "shasum": ""
             },
             "require": {
@@ -1192,7 +1508,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1219,20 +1535,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:36:10+00:00"
+            "time": "2019-01-16T20:35:37+00:00"
         },
         {
             "name": "tightenco/jigsaw",
-            "version": "v1.2.8",
+            "version": "v1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tightenco/jigsaw.git",
-                "reference": "29193e9e48b077469809e8b3b00408105fdfc936"
+                "reference": "fb9cd18e36ec78a77d6151b37bbc41a6c12f4418"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tightenco/jigsaw/zipball/29193e9e48b077469809e8b3b00408105fdfc936",
-                "reference": "29193e9e48b077469809e8b3b00408105fdfc936",
+                "url": "https://api.github.com/repos/tightenco/jigsaw/zipball/fb9cd18e36ec78a77d6151b37bbc41a6c12f4418",
+                "reference": "fb9cd18e36ec78a77d6151b37bbc41a6c12f4418",
                 "shasum": ""
             },
             "require": {
@@ -1243,9 +1559,13 @@
                 "mnapoli/front-yaml": "^1.5",
                 "mockery/mockery": "^1.0.0",
                 "symfony/console": "~3.0|^4.0",
+                "symfony/dotenv": "^4.2",
+                "symfony/process": "~3.0|^4.0",
+                "symfony/var-dumper": "^4.0",
                 "symfony/yaml": "^4.0"
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.12",
                 "mikey179/vfsstream": "^1.6",
                 "phpunit/phpunit": "~7.0"
             },
@@ -1279,10 +1599,59 @@
                 "site",
                 "static"
             ],
-            "time": "2018-08-02T14:25:24+00:00"
+            "time": "2019-02-05T14:14:15+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "malukenho/mcbumpface",
+            "version": "0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/malukenho/mcbumpface.git",
+                "reference": "f20c46a7ae697fcb41a18893c4013eb9a1751d6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/malukenho/mcbumpface/zipball/f20c46a7ae697fcb41a18893c4013eb9a1751d6c",
+                "reference": "f20c46a7ae697fcb41a18893c4013eb9a1751d6c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0.0",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "composer/composer": "^1.6.3",
+                "doctrine/coding-standard": "^4.0",
+                "ext-zip": "*",
+                "infection/infection": "^0.7.1",
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": "^7.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Malukenho\\McBumpface\\BumpInto"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Malukenho\\McBumpface\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jefersson Nathan",
+                    "email": "malukenho@phpse.net"
+                }
+            ],
+            "description": "Bumping into packages",
+            "time": "2018-12-28T13:39:52+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,10 +2,1041 @@
     "requires": true,
     "lockfileVersion": 1,
     "dependencies": {
-        "abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/core": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
+            "integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.2.2",
+                "@babel/helpers": "^7.2.0",
+                "@babel/parser": "^7.2.2",
+                "@babel/template": "^7.2.2",
+                "@babel/traverse": "^7.2.2",
+                "@babel/types": "^7.2.2",
+                "convert-source-map": "^1.1.0",
+                "debug": "^4.1.0",
+                "json5": "^2.1.0",
+                "lodash": "^4.17.10",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
+            "integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.3.2",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.10",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            }
+        },
+        "@babel/helper-annotate-as-pure": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+            "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+            "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-explode-assignable-expression": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-call-delegate": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
+            "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.0.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-define-map": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
+            "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "lodash": "^4.17.10"
+            }
+        },
+        "@babel/helper-explode-assignable-expression": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+            "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
+            "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+            "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+            "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
+            "integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-simple-access": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/template": "^7.2.2",
+                "@babel/types": "^7.2.2",
+                "lodash": "^4.17.10"
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+            "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+            "dev": true
+        },
+        "@babel/helper-regex": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+            "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.10"
+            }
+        },
+        "@babel/helper-remap-async-to-generator": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+            "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-wrap-function": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz",
+            "integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.0.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/traverse": "^7.2.3",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+            "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+            "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-wrap-function": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+            "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.2.0"
+            }
+        },
+        "@babel/helpers": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
+            "integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.1.2",
+                "@babel/traverse": "^7.1.5",
+                "@babel/types": "^7.3.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/parser": {
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
+            "integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
+            "dev": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+            "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.1.0",
+                "@babel/plugin-syntax-async-generators": "^7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-json-strings": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+            "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-json-strings": "^7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz",
+            "integrity": "sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+            "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz",
+            "integrity": "sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.2.0"
+            }
+        },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+            "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+            "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+            "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+            "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+            "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz",
+            "integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.1.0"
+            }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+            "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-block-scoping": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz",
+            "integrity": "sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "lodash": "^4.17.10"
+            }
+        },
+        "@babel/plugin-transform-classes": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.2.2.tgz",
+            "integrity": "sha512-gEZvgTy1VtcDOaQty1l10T3jQmJKlNVxLDCs+3rCVPr6nMkODLELxViq5X9l+rfxbie3XrfrMCYYY6eX3aOcOQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-define-map": "^7.1.0",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "globals": "^11.1.0"
+            }
+        },
+        "@babel/plugin-transform-computed-properties": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+            "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-destructuring": {
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz",
+            "integrity": "sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
+            "integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.1.3"
+            }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
+            "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+            "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-for-of": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz",
+            "integrity": "sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-function-name": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
+            "integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-literals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+            "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-amd": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
+            "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
+            "integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-simple-access": "^7.1.0"
+            }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz",
+            "integrity": "sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-umd": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+            "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.3.0.tgz",
+            "integrity": "sha512-NxIoNVhk9ZxS+9lSoAQ/LM0V2UEvARLttEHUrRDGKFaAxOYQcrkN/nLRE+BbbicCAvZPl7wMP0X60HsHE5DtQw==",
+            "dev": true,
+            "requires": {
+                "regexp-tree": "^0.1.0"
+            }
+        },
+        "@babel/plugin-transform-new-target": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
+            "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-object-super": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+            "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.1.0"
+            }
+        },
+        "@babel/plugin-transform-parameters": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.2.0.tgz",
+            "integrity": "sha512-kB9+hhUidIgUoBQ0MsxMewhzr8i60nMa2KgeJKQWYrqQpqcBYtnpR+JgkadZVZoaEZ/eKu9mclFaVwhRpLNSzA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-call-delegate": "^7.1.0",
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-regenerator": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+            "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+            "dev": true,
+            "requires": {
+                "regenerator-transform": "^0.13.3"
+            }
+        },
+        "@babel/plugin-transform-runtime": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
+            "integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "resolve": "^1.8.1",
+                "semver": "^5.5.1"
+            }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+            "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-spread": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+            "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+            "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-template-literals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
+            "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+            "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
+            "integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.1.3"
+            }
+        },
+        "@babel/preset-env": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.1.tgz",
+            "integrity": "sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+                "@babel/plugin-proposal-json-strings": "^7.2.0",
+                "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
+                "@babel/plugin-syntax-async-generators": "^7.2.0",
+                "@babel/plugin-syntax-json-strings": "^7.2.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+                "@babel/plugin-transform-arrow-functions": "^7.2.0",
+                "@babel/plugin-transform-async-to-generator": "^7.2.0",
+                "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+                "@babel/plugin-transform-block-scoping": "^7.2.0",
+                "@babel/plugin-transform-classes": "^7.2.0",
+                "@babel/plugin-transform-computed-properties": "^7.2.0",
+                "@babel/plugin-transform-destructuring": "^7.2.0",
+                "@babel/plugin-transform-dotall-regex": "^7.2.0",
+                "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+                "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+                "@babel/plugin-transform-for-of": "^7.2.0",
+                "@babel/plugin-transform-function-name": "^7.2.0",
+                "@babel/plugin-transform-literals": "^7.2.0",
+                "@babel/plugin-transform-modules-amd": "^7.2.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.2.0",
+                "@babel/plugin-transform-modules-systemjs": "^7.2.0",
+                "@babel/plugin-transform-modules-umd": "^7.2.0",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
+                "@babel/plugin-transform-new-target": "^7.0.0",
+                "@babel/plugin-transform-object-super": "^7.2.0",
+                "@babel/plugin-transform-parameters": "^7.2.0",
+                "@babel/plugin-transform-regenerator": "^7.0.0",
+                "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+                "@babel/plugin-transform-spread": "^7.2.0",
+                "@babel/plugin-transform-sticky-regex": "^7.2.0",
+                "@babel/plugin-transform-template-literals": "^7.2.0",
+                "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+                "@babel/plugin-transform-unicode-regex": "^7.2.0",
+                "browserslist": "^4.3.4",
+                "invariant": "^2.2.2",
+                "js-levenshtein": "^1.1.3",
+                "semver": "^5.3.0"
+            }
+        },
+        "@babel/runtime": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+            "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+            "dev": true,
+            "requires": {
+                "regenerator-runtime": "^0.12.0"
+            }
+        },
+        "@babel/template": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+            "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.2.2",
+                "@babel/types": "^7.2.2"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+            "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.2.2",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.2.3",
+                "@babel/types": "^7.2.2",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.10"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
+            "integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@mrmlnc/readdir-enhanced": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+            "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+            "dev": true,
+            "requires": {
+                "call-me-maybe": "^1.0.1",
+                "glob-to-regexp": "^0.3.0"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+            "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+            "dev": true
+        },
+        "@types/q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
+            "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==",
+            "dev": true
+        },
+        "@vue/component-compiler-utils": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.5.2.tgz",
+            "integrity": "sha512-3exq9O89GXo9E+CGKzgURCbasG15FtFMs8QRrCUVWGaKue4Egpw41MHb3Avtikv1VykKfBq3FvAnf9Nx3sdVJg==",
+            "dev": true,
+            "requires": {
+                "consolidate": "^0.15.1",
+                "hash-sum": "^1.0.2",
+                "lru-cache": "^4.1.2",
+                "merge-source-map": "^1.1.0",
+                "postcss": "^7.0.14",
+                "postcss-selector-parser": "^5.0.0",
+                "prettier": "1.16.3",
+                "source-map": "~0.6.1",
+                "vue-template-es2015-compiler": "^1.8.2"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@webassemblyjs/ast": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
+            "integrity": "sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/helper-module-context": "1.7.11",
+                "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+                "@webassemblyjs/wast-parser": "1.7.11"
+            }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz",
+            "integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-api-error": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz",
+            "integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-buffer": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
+            "integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-code-frame": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz",
+            "integrity": "sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/wast-printer": "1.7.11"
+            }
+        },
+        "@webassemblyjs/helper-fsm": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz",
+            "integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-module-context": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz",
+            "integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz",
+            "integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
+            "integrity": "sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.7.11",
+                "@webassemblyjs/helper-buffer": "1.7.11",
+                "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+                "@webassemblyjs/wasm-gen": "1.7.11"
+            }
+        },
+        "@webassemblyjs/ieee754": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
+            "integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
+            "dev": true,
+            "requires": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "@webassemblyjs/leb128": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
+            "integrity": "sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==",
+            "dev": true,
+            "requires": {
+                "@xtuc/long": "4.2.1"
+            }
+        },
+        "@webassemblyjs/utf8": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
+            "integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==",
+            "dev": true
+        },
+        "@webassemblyjs/wasm-edit": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
+            "integrity": "sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.7.11",
+                "@webassemblyjs/helper-buffer": "1.7.11",
+                "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+                "@webassemblyjs/helper-wasm-section": "1.7.11",
+                "@webassemblyjs/wasm-gen": "1.7.11",
+                "@webassemblyjs/wasm-opt": "1.7.11",
+                "@webassemblyjs/wasm-parser": "1.7.11",
+                "@webassemblyjs/wast-printer": "1.7.11"
+            }
+        },
+        "@webassemblyjs/wasm-gen": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
+            "integrity": "sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.7.11",
+                "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+                "@webassemblyjs/ieee754": "1.7.11",
+                "@webassemblyjs/leb128": "1.7.11",
+                "@webassemblyjs/utf8": "1.7.11"
+            }
+        },
+        "@webassemblyjs/wasm-opt": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
+            "integrity": "sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.7.11",
+                "@webassemblyjs/helper-buffer": "1.7.11",
+                "@webassemblyjs/wasm-gen": "1.7.11",
+                "@webassemblyjs/wasm-parser": "1.7.11"
+            }
+        },
+        "@webassemblyjs/wasm-parser": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
+            "integrity": "sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.7.11",
+                "@webassemblyjs/helper-api-error": "1.7.11",
+                "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+                "@webassemblyjs/ieee754": "1.7.11",
+                "@webassemblyjs/leb128": "1.7.11",
+                "@webassemblyjs/utf8": "1.7.11"
+            }
+        },
+        "@webassemblyjs/wast-parser": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz",
+            "integrity": "sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.7.11",
+                "@webassemblyjs/floating-point-hex-parser": "1.7.11",
+                "@webassemblyjs/helper-api-error": "1.7.11",
+                "@webassemblyjs/helper-code-frame": "1.7.11",
+                "@webassemblyjs/helper-fsm": "1.7.11",
+                "@xtuc/long": "4.2.1"
+            }
+        },
+        "@webassemblyjs/wast-printer": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz",
+            "integrity": "sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.7.11",
+                "@webassemblyjs/wast-parser": "1.7.11",
+                "@xtuc/long": "4.2.1"
+            }
+        },
+        "@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true
+        },
+        "@xtuc/long": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
+            "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
             "dev": true
         },
         "accepts": {
@@ -19,73 +1050,16 @@
             }
         },
         "acorn": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-            "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+            "version": "6.0.7",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.7.tgz",
+            "integrity": "sha512-HNJNgE60C9eOTgn974Tlp3dpLZdUr+SoxxDwPaY9J/kDNOLQTkaDgwBUXAF4SSsrAwD9RpdxuHK/EbuF+W9Ahw==",
             "dev": true
         },
         "acorn-dynamic-import": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-            "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-            "dev": true,
-            "requires": {
-                "acorn": "^4.0.3"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "4.0.13",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-                    "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-                    "dev": true
-                }
-            }
-        },
-        "adjust-sourcemap-loader": {
-            "version": "1.2.0",
-            "resolved": "http://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-1.2.0.tgz",
-            "integrity": "sha512-958oaHHVEXMvsY7v7cC5gEkNIcoaAVIhZ4mBReYVZJOTP9IgKmzLjIOhTtzpLMu+qriXvLsVjJ155EeInp45IQ==",
-            "dev": true,
-            "requires": {
-                "assert": "^1.3.0",
-                "camelcase": "^1.2.1",
-                "loader-utils": "^1.1.0",
-                "lodash.assign": "^4.0.1",
-                "lodash.defaults": "^3.1.2",
-                "object-path": "^0.9.2",
-                "regex-parser": "^2.2.9"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                    "dev": true
-                },
-                "lodash.defaults": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-                    "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
-                    "dev": true,
-                    "requires": {
-                        "lodash.assign": "^3.0.0",
-                        "lodash.restparam": "^3.0.0"
-                    },
-                    "dependencies": {
-                        "lodash.assign": {
-                            "version": "3.2.0",
-                            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-                            "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-                            "dev": true,
-                            "requires": {
-                                "lodash._baseassign": "^3.0.0",
-                                "lodash._createassigner": "^3.0.0",
-                                "lodash.keys": "^3.0.0"
-                            }
-                        }
-                    }
-                }
-            }
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+            "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
+            "dev": true
         },
         "after": {
             "version": "0.8.2",
@@ -94,44 +1068,28 @@
             "dev": true
         },
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
+            "integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
+                "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
         },
-        "ajv-keywords": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-            "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+        "ajv-errors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+            "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
             "dev": true
         },
-        "align-text": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-            "dev": true,
-            "requires": {
-                "kind-of": "^3.0.2",
-                "longest": "^1.0.1",
-                "repeat-string": "^1.5.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
+        "ajv-keywords": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.3.0.tgz",
+            "integrity": "sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g==",
+            "dev": true
         },
         "alphanum-sort": {
             "version": "1.0.2",
@@ -139,10 +1097,10 @@
             "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
             "dev": true
         },
-        "amdefine": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+        "ansi-colors": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+            "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
             "dev": true
         },
         "ansi-html": {
@@ -202,16 +1160,6 @@
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "dev": true
         },
-        "are-we-there-yet": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-            "dev": true,
-            "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-            }
-        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -239,27 +1187,11 @@
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
         },
-        "array-find-index": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-            "dev": true
-        },
         "array-flatten": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-            "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+            "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
             "dev": true
-        },
-        "array-includes": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-            "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.7.0"
-            }
         },
         "array-union": {
             "version": "1.0.2",
@@ -288,14 +1220,11 @@
             "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
             "dev": true
         },
-        "asn1": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-            "dev": true,
-            "requires": {
-                "safer-buffer": "~2.1.0"
-            }
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
         },
         "asn1.js": {
             "version": "4.10.1",
@@ -316,12 +1245,6 @@
             "requires": {
                 "util": "0.10.3"
             }
-        },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "dev": true
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -353,22 +1276,10 @@
             "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
             "dev": true
         },
-        "async-foreach": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-            "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
-            "dev": true
-        },
         "async-limiter": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
             "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-            "dev": true
-        },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
         "atob": {
@@ -378,30 +1289,28 @@
             "dev": true
         },
         "autoprefixer": {
-            "version": "7.2.6",
-            "resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
-            "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+            "version": "9.4.7",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.7.tgz",
+            "integrity": "sha512-qS5wW6aXHkm53Y4z73tFGsUhmZu4aMPV9iHXYlF0c/wxjknXNHuj/1cIQb+6YH692DbJGGWcckAXX+VxKvahMA==",
             "dev": true,
             "requires": {
-                "browserslist": "^2.11.3",
-                "caniuse-lite": "^1.0.30000805",
+                "browserslist": "^4.4.1",
+                "caniuse-lite": "^1.0.30000932",
                 "normalize-range": "^0.1.2",
                 "num2fraction": "^1.2.2",
-                "postcss": "^6.0.17",
-                "postcss-value-parser": "^3.2.3"
+                "postcss": "^7.0.14",
+                "postcss-value-parser": "^3.3.1"
             }
         },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "dev": true
-        },
-        "aws4": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-            "dev": true
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "dev": true,
+            "requires": {
+                "follow-redirects": "^1.2.5",
+                "is-buffer": "^1.1.5"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -412,679 +1321,58 @@
                 "chalk": "^1.1.3",
                 "esutils": "^2.0.2",
                 "js-tokens": "^3.0.2"
-            }
-        },
-        "babel-core": {
-            "version": "6.26.3",
-            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-            "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-            "dev": true,
-            "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-generator": "^6.26.0",
-                "babel-helpers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-register": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "convert-source-map": "^1.5.1",
-                "debug": "^2.6.9",
-                "json5": "^0.5.1",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.4",
-                "path-is-absolute": "^1.0.1",
-                "private": "^0.1.8",
-                "slash": "^1.0.0",
-                "source-map": "^0.5.7"
             },
             "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
                 }
-            }
-        },
-        "babel-generator": {
-            "version": "6.26.1",
-            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-            "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-            "dev": true,
-            "requires": {
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "detect-indent": "^4.0.0",
-                "jsesc": "^1.3.0",
-                "lodash": "^4.17.4",
-                "source-map": "^0.5.7",
-                "trim-right": "^1.0.1"
-            }
-        },
-        "babel-helper-builder-binary-assignment-operator-visitor": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-            "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-            "dev": true,
-            "requires": {
-                "babel-helper-explode-assignable-expression": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-call-delegate": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-            "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-            "dev": true,
-            "requires": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-define-map": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-            "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-helper-explode-assignable-expression": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-            "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-function-name": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-            "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-            "dev": true,
-            "requires": {
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-get-function-arity": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-            "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-hoist-variables": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-            "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-optimise-call-expression": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-            "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-regex": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-            "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-helper-remap-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-replace-supers": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-            "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-            "dev": true,
-            "requires": {
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helpers": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-            "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
             }
         },
         "babel-loader": {
-            "version": "7.1.5",
-            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
-            "integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.5.tgz",
+            "integrity": "sha512-NTnHnVRd2JnRqPC0vW+iOQWU5pchDbYXsG2E6DMXEpMfUcQKclF9gmf3G3ZMhzG7IG9ji4coL0cm+FxeWxDpnw==",
             "dev": true,
             "requires": {
-                "find-cache-dir": "^1.0.0",
+                "find-cache-dir": "^2.0.0",
                 "loader-utils": "^1.0.2",
-                "mkdirp": "^0.5.1"
-            }
-        },
-        "babel-messages": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-check-es2015-constants": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-            "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-syntax-async-functions": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-            "dev": true
-        },
-        "babel-plugin-syntax-exponentiation-operator": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-            "dev": true
-        },
-        "babel-plugin-syntax-object-rest-spread": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-            "dev": true
-        },
-        "babel-plugin-syntax-trailing-function-commas": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-            "dev": true
-        },
-        "babel-plugin-transform-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-            "dev": true,
-            "requires": {
-                "babel-helper-remap-async-to-generator": "^6.24.1",
-                "babel-plugin-syntax-async-functions": "^6.8.0",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-            "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-            "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-            "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-plugin-transform-es2015-classes": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-            "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-            "dev": true,
-            "requires": {
-                "babel-helper-define-map": "^6.24.1",
-                "babel-helper-function-name": "^6.24.1",
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-            "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-            "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-duplicate-keys": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-            "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-for-of": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-            "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-function-name": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-            "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-literals": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-            "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-amd": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-            "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "6.26.2",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-            "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-strict-mode": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-types": "^6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-systemjs": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-            "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-            "dev": true,
-            "requires": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-umd": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-            "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-object-super": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-            "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-            "dev": true,
-            "requires": {
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-            "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-            "dev": true,
-            "requires": {
-                "babel-helper-call-delegate": "^6.24.1",
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-            "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-spread": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-            "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-            "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-            "dev": true,
-            "requires": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-            "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-            "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-            "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-            "dev": true,
-            "requires": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "regexpu-core": "^2.0.0"
-            }
-        },
-        "babel-plugin-transform-exponentiation-operator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-            "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-            "dev": true,
-            "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-object-rest-spread": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-            "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-                "babel-runtime": "^6.26.0"
-            }
-        },
-        "babel-plugin-transform-regenerator": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-            "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-            "dev": true,
-            "requires": {
-                "regenerator-transform": "^0.10.0"
-            }
-        },
-        "babel-plugin-transform-runtime": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-            "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-strict-mode": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-            "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-preset-env": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-            "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-            "dev": true,
-            "requires": {
-                "babel-plugin-check-es2015-constants": "^6.22.0",
-                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-                "babel-plugin-transform-async-to-generator": "^6.22.0",
-                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-                "babel-plugin-transform-es2015-classes": "^6.23.0",
-                "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-                "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-                "babel-plugin-transform-es2015-for-of": "^6.23.0",
-                "babel-plugin-transform-es2015-function-name": "^6.22.0",
-                "babel-plugin-transform-es2015-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-                "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-                "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-                "babel-plugin-transform-es2015-object-super": "^6.22.0",
-                "babel-plugin-transform-es2015-parameters": "^6.23.0",
-                "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-                "babel-plugin-transform-es2015-spread": "^6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-                "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-                "babel-plugin-transform-regenerator": "^6.22.0",
-                "browserslist": "^3.2.6",
-                "invariant": "^2.2.2",
-                "semver": "^5.3.0"
-            },
-            "dependencies": {
-                "browserslist": {
-                    "version": "3.2.8",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-                    "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-                    "dev": true,
-                    "requires": {
-                        "caniuse-lite": "^1.0.30000844",
-                        "electron-to-chromium": "^1.3.47"
-                    }
-                }
-            }
-        },
-        "babel-register": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-            "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-            "dev": true,
-            "requires": {
-                "babel-core": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "core-js": "^2.5.0",
-                "home-or-tmp": "^2.0.0",
-                "lodash": "^4.17.4",
                 "mkdirp": "^0.5.1",
-                "source-map-support": "^0.4.15"
+                "util.promisify": "^1.0.0"
             }
         },
-        "babel-runtime": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+        "babel-merge": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/babel-merge/-/babel-merge-2.0.1.tgz",
+            "integrity": "sha512-puTQQxuzS+0JlMyVdfsTVaCgzqjBXKPMv7oUANpYcHFY+7IptWZ4PZDYX+qBxrRMtrriuBA44LkKpS99EJzqVA==",
             "dev": true,
             "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
-            }
-        },
-        "babel-template": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-traverse": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-            "dev": true,
-            "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "debug": "^2.6.8",
-                "globals": "^9.18.0",
-                "invariant": "^2.2.2",
-                "lodash": "^4.17.4"
+                "@babel/core": "^7.0.0-beta.49",
+                "deepmerge": "^2.1.0",
+                "object.omit": "^3.0.0"
             },
             "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "is-plain-object": "^2.0.4"
+                    }
+                },
+                "object.omit": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-3.0.0.tgz",
+                    "integrity": "sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^1.0.0"
                     }
                 }
             }
-        },
-        "babel-types": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
-            }
-        },
-        "babylon": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-            "dev": true
         },
         "backo2": {
             "version": "1.0.2",
@@ -1177,16 +1465,6 @@
             "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
             "dev": true
         },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
         "better-assert": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
@@ -1197,9 +1475,9 @@
             }
         },
         "big.js": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
             "dev": true
         },
         "binary-extensions": {
@@ -1209,24 +1487,15 @@
             "dev": true
         },
         "blob": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-            "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+            "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
             "dev": true
         },
-        "block-stream": {
-            "version": "0.0.9",
-            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-            "dev": true,
-            "requires": {
-                "inherits": "~2.0.0"
-            }
-        },
         "bluebird": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-            "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+            "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
             "dev": true
         },
         "bn.js": {
@@ -1236,21 +1505,21 @@
             "dev": true
         },
         "body-parser": {
-            "version": "1.18.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-            "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+            "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
                 "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "~1.1.1",
-                "http-errors": "~1.6.2",
-                "iconv-lite": "0.4.19",
+                "depd": "~1.1.2",
+                "http-errors": "~1.6.3",
+                "iconv-lite": "0.4.23",
                 "on-finished": "~2.3.0",
-                "qs": "6.5.1",
-                "raw-body": "2.3.2",
-                "type-is": "~1.6.15"
+                "qs": "6.5.2",
+                "raw-body": "2.3.3",
+                "type-is": "~1.6.16"
             },
             "dependencies": {
                 "debug": {
@@ -1262,54 +1531,10 @@
                         "ms": "2.0.0"
                     }
                 },
-                "iconv-lite": {
-                    "version": "0.4.19",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-                    "dev": true
-                },
                 "qs": {
-                    "version": "6.5.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-                    "dev": true
-                },
-                "raw-body": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-                    "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-                    "dev": true,
-                    "requires": {
-                        "bytes": "3.0.0",
-                        "http-errors": "1.6.2",
-                        "iconv-lite": "0.4.19",
-                        "unpipe": "1.0.0"
-                    },
-                    "dependencies": {
-                        "depd": {
-                            "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-                            "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-                            "dev": true
-                        },
-                        "http-errors": {
-                            "version": "1.6.2",
-                            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-                            "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-                            "dev": true,
-                            "requires": {
-                                "depd": "1.1.1",
-                                "inherits": "2.0.3",
-                                "setprototypeof": "1.0.3",
-                                "statuses": ">= 1.3.1 < 2"
-                            }
-                        }
-                    }
-                },
-                "setprototypeof": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-                    "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
                     "dev": true
                 }
             }
@@ -1327,6 +1552,12 @@
                 "multicast-dns": "^6.0.1",
                 "multicast-dns-service-types": "^1.1.0"
             }
+        },
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+            "dev": true
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -1374,13 +1605,13 @@
             "dev": true
         },
         "browser-sync": {
-            "version": "2.26.0",
-            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.0.tgz",
-            "integrity": "sha512-/2f2/jPmFEdPw7wcARid/oGO237RMfZ8SyAYVtF4Zq5R/E+78zx/rH6aFc/UFY+VDHcsCqmDsfIEi/q1fA3l4Q==",
+            "version": "2.26.3",
+            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.3.tgz",
+            "integrity": "sha512-VLzpjCA4uXqfzkwqWtMM6hvPm2PNHp2RcmzBXcbi6C9WpkUhhFb8SVAr4CFrCsFxDg+oY6HalOjn8F+egyvhag==",
             "dev": true,
             "requires": {
-                "browser-sync-client": "^2.26.0",
-                "browser-sync-ui": "^2.26.0",
+                "browser-sync-client": "^2.26.2",
+                "browser-sync-ui": "^2.26.2",
                 "bs-recipes": "1.3.4",
                 "bs-snippet-injector": "^2.0.1",
                 "chokidar": "^2.0.4",
@@ -1402,6 +1633,7 @@
                 "raw-body": "^2.3.2",
                 "resp-modifier": "6.0.2",
                 "rx": "4.1.0",
+                "send": "0.16.2",
                 "serve-index": "1.9.1",
                 "serve-static": "1.13.2",
                 "server-destroy": "1.0.1",
@@ -1435,19 +1667,21 @@
             }
         },
         "browser-sync-client": {
-            "version": "2.26.0",
-            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.0.tgz",
-            "integrity": "sha512-XRVN6xNFCQYb5mjrDoVzdV2rBK6PMLtTeYkKcs5UPp+/cuviB8z8odaHx0Oe/cAs3Vl45csRdpa7T+q1Zf+6qQ==",
+            "version": "2.26.2",
+            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.2.tgz",
+            "integrity": "sha512-FEuVJD41fI24HJ30XOT2RyF5WcnEtdJhhTqeyDlnMk/8Ox9MZw109rvk9pdfRWye4soZLe+xcAo9tHSMxvgAdw==",
             "dev": true,
             "requires": {
+                "etag": "1.8.1",
+                "fresh": "0.5.2",
                 "mitt": "^1.1.3",
                 "rxjs": "^5.5.6"
             }
         },
         "browser-sync-ui": {
-            "version": "2.26.0",
-            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.0.tgz",
-            "integrity": "sha512-7bXPmkQ9GuSPUgji3Nb4y0IL8wS2LfdrKSG28bQwvys5bs4kWyXDec2RkYBiupTTModM5lbwXgtmoh7GWQuLGg==",
+            "version": "2.26.2",
+            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.2.tgz",
+            "integrity": "sha512-LF7GMWo8ELOE0eAlxuRCfnGQT1ZxKP9flCfGgZdXFc6BwmoqaJHlYe7MmVvykKkXjolRXTz8ztXAKGVqNwJ3EQ==",
             "dev": true,
             "requires": {
                 "async-each-series": "0.1.1",
@@ -1469,7 +1703,7 @@
         },
         "browserify-aes": {
             "version": "1.2.0",
-            "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
@@ -1506,7 +1740,7 @@
         },
         "browserify-rsa": {
             "version": "4.0.1",
-            "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
@@ -1539,13 +1773,14 @@
             }
         },
         "browserslist": {
-            "version": "2.11.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-            "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.1.tgz",
+            "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30000792",
-                "electron-to-chromium": "^1.3.30"
+                "caniuse-lite": "^1.0.30000929",
+                "electron-to-chromium": "^1.3.103",
+                "node-releases": "^1.1.3"
             }
         },
         "bs-recipes": {
@@ -1562,7 +1797,7 @@
         },
         "buffer": {
             "version": "4.9.1",
-            "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
@@ -1610,9 +1845,9 @@
             "dev": true
         },
         "bulma": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.1.tgz",
-            "integrity": "sha512-wRSO2LXB+qI9Pyz2id+uZr4quz5aftSN7Ay1ysr1+krzVp3utD+Ci4CeKuZdrYGc800t65b7heXBL6qw2Wo/lQ==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.2.tgz",
+            "integrity": "sha512-6JHEu8U/1xsyOst/El5ImLcZIiE2JFXgvrz8GGWbnDLwTNRPJzdAM0aoUM1Ns0avALcVb6KZz9NhzmU53dGDcQ==",
             "dev": true
         },
         "bytes": {
@@ -1622,30 +1857,52 @@
             "dev": true
         },
         "cacache": {
-            "version": "10.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-            "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+            "version": "11.3.2",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+            "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
+                "bluebird": "^3.5.3",
+                "chownr": "^1.1.1",
+                "figgy-pudding": "^3.5.1",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.1.15",
+                "lru-cache": "^5.1.1",
+                "mississippi": "^3.0.0",
                 "mkdirp": "^0.5.1",
                 "move-concurrently": "^1.0.1",
                 "promise-inflight": "^1.0.1",
                 "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
+                "ssri": "^6.0.1",
+                "unique-filename": "^1.1.1",
                 "y18n": "^4.0.0"
             },
             "dependencies": {
+                "graceful-fs": {
+                    "version": "4.1.15",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^3.0.2"
+                    }
+                },
                 "y18n": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
                     "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
                     "dev": true
                 }
             }
@@ -1667,10 +1924,40 @@
                 "unset-value": "^1.0.0"
             }
         },
+        "call-me-maybe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+            "dev": true
+        },
+        "caller-callsite": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+            "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+            "dev": true,
+            "requires": {
+                "callsites": "^2.0.0"
+            }
+        },
+        "caller-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+            "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+            "dev": true,
+            "requires": {
+                "caller-callsite": "^2.0.0"
+            }
+        },
         "callsite": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
             "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+            "dev": true
+        },
+        "callsites": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+            "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
             "dev": true
         },
         "camel-case": {
@@ -1689,75 +1976,23 @@
             "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
             "dev": true
         },
-        "camelcase-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-            "dev": true,
-            "requires": {
-                "camelcase": "^2.0.0",
-                "map-obj": "^1.0.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-                    "dev": true
-                }
-            }
-        },
         "caniuse-api": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
-            "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+            "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
             "dev": true,
             "requires": {
-                "browserslist": "^1.3.6",
-                "caniuse-db": "^1.0.30000529",
+                "browserslist": "^4.0.0",
+                "caniuse-lite": "^1.0.0",
                 "lodash.memoize": "^4.1.2",
                 "lodash.uniq": "^4.5.0"
-            },
-            "dependencies": {
-                "browserslist": {
-                    "version": "1.7.7",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-                    "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-                    "dev": true,
-                    "requires": {
-                        "caniuse-db": "^1.0.30000639",
-                        "electron-to-chromium": "^1.2.7"
-                    }
-                }
             }
-        },
-        "caniuse-db": {
-            "version": "1.0.30000890",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000890.tgz",
-            "integrity": "sha512-aO5uw1Taw8GkNMMXIWOz/WJz3y6tR1ETUAdH/pvO5EoJ3I1Po9vNJd9aMjY1GKucS/OXWMiQbXRbk3O1sgCbRA==",
-            "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30000890",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000890.tgz",
-            "integrity": "sha512-4NI3s4Y6ROm+SgZN5sLUG4k7nVWQnedis3c/RWkynV5G6cHSY7+a8fwFyn2yoBDE3E6VswhTNNwR3PvzGqlTkg==",
+            "version": "1.0.30000935",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000935.tgz",
+            "integrity": "sha512-1Y2uJ5y56qDt3jsDTdBHL1OqiImzjoQcBG6Yl3Qizq8mcc2SgCFpi+ZwLLqkztYnk9l87IYqRlNBnPSOTbFkXQ==",
             "dev": true
-        },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-            "dev": true
-        },
-        "center-align": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-            "dev": true,
-            "requires": {
-                "align-text": "^0.1.3",
-                "lazy-cache": "^1.0.3"
-            }
         },
         "chainsaw": {
             "version": "0.0.9",
@@ -1787,24 +2022,560 @@
             "dev": true
         },
         "chokidar": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-            "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.0.tgz",
+            "integrity": "sha512-5t6G2SH8eO6lCvYOoUpaRnF5Qfd//gd7qJAkwRUw9qlGVkiQ13uwQngqbWWaurOsaAm9+kUGbITADxt6H0XFNQ==",
             "dev": true,
             "requires": {
                 "anymatch": "^2.0.0",
-                "async-each": "^1.0.0",
-                "braces": "^2.3.0",
-                "fsevents": "^1.2.2",
+                "async-each": "^1.0.1",
+                "braces": "^2.3.2",
+                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
-                "inherits": "^2.0.1",
+                "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
                 "is-glob": "^4.0.0",
-                "lodash.debounce": "^4.0.8",
-                "normalize-path": "^2.1.1",
+                "normalize-path": "^3.0.0",
                 "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0",
-                "upath": "^1.0.5"
+                "readdirp": "^2.2.1",
+                "upath": "^1.1.0"
+            },
+            "dependencies": {
+                "fsevents": {
+                    "version": "1.2.7",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+                    "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "nan": "^2.9.2",
+                        "node-pre-gyp": "^0.10.0"
+                    },
+                    "dependencies": {
+                        "abbrev": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "are-we-there-yet": {
+                            "version": "1.1.5",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "delegates": "^1.0.0",
+                                "readable-stream": "^2.0.6"
+                            }
+                        },
+                        "balanced-match": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "brace-expansion": {
+                            "version": "1.1.11",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "balanced-match": "^1.0.0",
+                                "concat-map": "0.0.1"
+                            }
+                        },
+                        "chownr": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "code-point-at": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "concat-map": {
+                            "version": "0.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "console-control-strings": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "core-util-is": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "debug": {
+                            "version": "2.6.9",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "deep-extend": {
+                            "version": "0.6.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "delegates": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "detect-libc": {
+                            "version": "1.0.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "fs-minipass": {
+                            "version": "1.2.5",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "minipass": "^2.2.1"
+                            }
+                        },
+                        "fs.realpath": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "gauge": {
+                            "version": "2.7.4",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "aproba": "^1.0.3",
+                                "console-control-strings": "^1.0.0",
+                                "has-unicode": "^2.0.0",
+                                "object-assign": "^4.1.0",
+                                "signal-exit": "^3.0.0",
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wide-align": "^1.1.0"
+                            }
+                        },
+                        "glob": {
+                            "version": "7.1.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        },
+                        "has-unicode": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "iconv-lite": {
+                            "version": "0.4.24",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "safer-buffer": ">= 2.1.2 < 3"
+                            }
+                        },
+                        "ignore-walk": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "minimatch": "^3.0.4"
+                            }
+                        },
+                        "inflight": {
+                            "version": "1.0.6",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "once": "^1.3.0",
+                                "wrappy": "1"
+                            }
+                        },
+                        "inherits": {
+                            "version": "2.0.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ini": {
+                            "version": "1.3.5",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "number-is-nan": "^1.0.0"
+                            }
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        },
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "minipass": {
+                            "version": "2.3.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
+                        },
+                        "minizlib": {
+                            "version": "1.2.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "minipass": "^2.2.1"
+                            }
+                        },
+                        "mkdirp": {
+                            "version": "0.5.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "minimist": "0.0.8"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "needle": {
+                            "version": "2.2.4",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "debug": "^2.1.2",
+                                "iconv-lite": "^0.4.4",
+                                "sax": "^1.2.4"
+                            }
+                        },
+                        "node-pre-gyp": {
+                            "version": "0.10.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "detect-libc": "^1.0.2",
+                                "mkdirp": "^0.5.1",
+                                "needle": "^2.2.1",
+                                "nopt": "^4.0.1",
+                                "npm-packlist": "^1.1.6",
+                                "npmlog": "^4.0.2",
+                                "rc": "^1.2.7",
+                                "rimraf": "^2.6.1",
+                                "semver": "^5.3.0",
+                                "tar": "^4"
+                            }
+                        },
+                        "nopt": {
+                            "version": "4.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "abbrev": "1",
+                                "osenv": "^0.1.4"
+                            }
+                        },
+                        "npm-bundled": {
+                            "version": "1.0.5",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "npm-packlist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "ignore-walk": "^3.0.1",
+                                "npm-bundled": "^1.0.1"
+                            }
+                        },
+                        "npmlog": {
+                            "version": "4.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "are-we-there-yet": "~1.1.2",
+                                "console-control-strings": "~1.1.0",
+                                "gauge": "~2.7.3",
+                                "set-blocking": "~2.0.0"
+                            }
+                        },
+                        "number-is-nan": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "object-assign": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "once": {
+                            "version": "1.4.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "wrappy": "1"
+                            }
+                        },
+                        "os-homedir": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "os-tmpdir": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "osenv": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "os-homedir": "^1.0.0",
+                                "os-tmpdir": "^1.0.0"
+                            }
+                        },
+                        "path-is-absolute": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "process-nextick-args": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "rc": {
+                            "version": "1.2.8",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "deep-extend": "^0.6.0",
+                                "ini": "~1.3.0",
+                                "minimist": "^1.2.0",
+                                "strip-json-comments": "~2.0.1"
+                            },
+                            "dependencies": {
+                                "minimist": {
+                                    "version": "1.2.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "optional": true
+                                }
+                            }
+                        },
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "rimraf": {
+                            "version": "2.6.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "glob": "^7.1.3"
+                            }
+                        },
+                        "safe-buffer": {
+                            "version": "5.1.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "safer-buffer": {
+                            "version": "2.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "sax": {
+                            "version": "1.2.4",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "semver": {
+                            "version": "5.6.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "set-blocking": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "signal-exit": {
+                            "version": "3.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^2.0.0"
+                            }
+                        },
+                        "strip-json-comments": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "tar": {
+                            "version": "4.4.8",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "chownr": "^1.1.1",
+                                "fs-minipass": "^1.2.5",
+                                "minipass": "^2.3.4",
+                                "minizlib": "^1.1.1",
+                                "mkdirp": "^0.5.0",
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.2"
+                            }
+                        },
+                        "util-deprecate": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "wide-align": {
+                            "version": "1.1.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "string-width": "^1.0.2 || 2"
+                            }
+                        },
+                        "wrappy": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "yallist": {
+                            "version": "3.0.3",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
+                }
             }
         },
         "chownr": {
@@ -1812,6 +2583,15 @@
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
             "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
             "dev": true
+        },
+        "chrome-trace-event": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
+            "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.0"
+            }
         },
         "cipher-base": {
             "version": "1.0.4",
@@ -1821,15 +2601,6 @@
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "clap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-            "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3"
             }
         },
         "class-utils": {
@@ -1872,6 +2643,50 @@
                 }
             }
         },
+        "cli-table3": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+            "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+            "dev": true,
+            "requires": {
+                "colors": "^1.1.2",
+                "object-assign": "^4.1.0",
+                "string-width": "^2.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
         "cliui": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -1883,48 +2698,46 @@
                 "wrap-ansi": "^2.0.0"
             }
         },
-        "clone": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-            "dev": true
-        },
-        "clone-deep": {
+        "coa": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
-            "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
+            "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+            "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
             "dev": true,
             "requires": {
-                "for-own": "^1.0.0",
-                "is-plain-object": "^2.0.4",
-                "kind-of": "^6.0.0",
-                "shallow-clone": "^1.0.0"
+                "@types/q": "^1.5.1",
+                "chalk": "^2.4.1",
+                "q": "^1.1.2"
             },
             "dependencies": {
-                "for-own": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "for-in": "^1.0.1"
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
                     }
                 }
-            }
-        },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
-        },
-        "coa": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-            "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-            "dev": true,
-            "requires": {
-                "q": "^1.1.2"
             }
         },
         "code-point-at": {
@@ -1944,14 +2757,13 @@
             }
         },
         "color": {
-            "version": "0.11.4",
-            "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
-            "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
+            "integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
             "dev": true,
             "requires": {
-                "clone": "^1.0.2",
-                "color-convert": "^1.3.0",
-                "color-string": "^0.3.0"
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
             }
         },
         "color-convert": {
@@ -1970,39 +2782,20 @@
             "dev": true
         },
         "color-string": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-            "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+            "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
             "dev": true,
             "requires": {
-                "color-name": "^1.0.0"
-            }
-        },
-        "colormin": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
-            "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-            "dev": true,
-            "requires": {
-                "color": "^0.11.0",
-                "css-color-names": "0.0.4",
-                "has": "^1.0.1"
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
             }
         },
         "colors": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+            "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
             "dev": true
-        },
-        "combined-stream": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-            "dev": true,
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
         },
         "commander": {
             "version": "2.19.0",
@@ -2120,9 +2913,9 @@
             }
         },
         "connect-history-api-fallback": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-            "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
             "dev": true
         },
         "console-browserify": {
@@ -2134,16 +2927,10 @@
                 "date-now": "^0.1.4"
             }
         },
-        "console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-            "dev": true
-        },
         "consolidate": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
-            "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
+            "version": "0.15.1",
+            "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
+            "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
             "dev": true,
             "requires": {
                 "bluebird": "^3.1.1"
@@ -2208,12 +2995,6 @@
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
-        "core-js": {
-            "version": "2.5.7",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-            "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-            "dev": true
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2221,33 +3002,17 @@
             "dev": true
         },
         "cosmiconfig": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-            "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
+            "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
             "dev": true,
             "requires": {
+                "import-fresh": "^2.0.0",
                 "is-directory": "^0.3.1",
                 "js-yaml": "^3.9.0",
-                "parse-json": "^4.0.0",
-                "require-from-string": "^2.0.1"
+                "parse-json": "^4.0.0"
             },
             "dependencies": {
-                "esprima": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-                    "dev": true
-                },
-                "js-yaml": {
-                    "version": "3.12.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-                    "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "^1.0.7",
-                        "esprima": "^4.0.0"
-                    }
-                },
                 "parse-json": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -2272,7 +3037,7 @@
         },
         "create-hash": {
             "version": "1.2.0",
-            "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
@@ -2285,7 +3050,7 @@
         },
         "create-hmac": {
             "version": "1.1.7",
-            "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
@@ -2343,46 +3108,34 @@
                 "randomfill": "^1.0.3"
             }
         },
-        "css": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-            "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-            "dev": true,
-            "requires": {
-                "inherits": "^2.0.3",
-                "source-map": "^0.6.1",
-                "source-map-resolve": "^0.5.2",
-                "urix": "^0.1.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
         "css-color-names": {
             "version": "0.0.4",
-            "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
             "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
             "dev": true
         },
+        "css-declaration-sorter": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+            "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
+            "dev": true,
+            "requires": {
+                "postcss": "^7.0.1",
+                "timsort": "^0.3.0"
+            }
+        },
         "css-loader": {
-            "version": "0.28.11",
-            "resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
-            "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
+            "integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
             "dev": true,
             "requires": {
                 "babel-code-frame": "^6.26.0",
                 "css-selector-tokenizer": "^0.7.0",
-                "cssnano": "^3.10.0",
                 "icss-utils": "^2.1.0",
                 "loader-utils": "^1.0.2",
-                "lodash.camelcase": "^4.3.0",
-                "object-assign": "^4.1.1",
-                "postcss": "^5.0.6",
+                "lodash": "^4.17.11",
+                "postcss": "^6.0.23",
                 "postcss-modules-extract-imports": "^1.2.0",
                 "postcss-modules-local-by-default": "^1.2.0",
                 "postcss-modules-scope": "^1.1.0",
@@ -2391,39 +3144,76 @@
                 "source-list-map": "^2.0.0"
             },
             "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
+                        "color-convert": "^1.9.0"
                     }
                 },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^1.0.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
         },
+        "css-select": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
+            "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+            "dev": true,
+            "requires": {
+                "boolbase": "^1.0.0",
+                "css-what": "^2.1.2",
+                "domutils": "^1.7.0",
+                "nth-check": "^1.0.2"
+            }
+        },
+        "css-select-base-adapter": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+            "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+            "dev": true
+        },
         "css-selector-tokenizer": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-            "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+            "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
             "dev": true,
             "requires": {
                 "cssesc": "^0.1.0",
@@ -2431,6 +3221,12 @@
                 "regexpu-core": "^1.0.0"
             },
             "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                },
                 "regexpu-core": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
@@ -2441,8 +3237,51 @@
                         "regjsgen": "^0.2.0",
                         "regjsparser": "^0.1.4"
                     }
+                },
+                "regjsgen": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                    "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+                    "dev": true
+                },
+                "regjsparser": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                    "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+                    "dev": true,
+                    "requires": {
+                        "jsesc": "~0.5.0"
+                    }
                 }
             }
+        },
+        "css-tree": {
+            "version": "1.0.0-alpha.28",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
+            "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+            "dev": true,
+            "requires": {
+                "mdn-data": "~1.1.0",
+                "source-map": "^0.5.3"
+            }
+        },
+        "css-unit-converter": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+            "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
+            "dev": true
+        },
+        "css-url-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
+            "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
+            "dev": true
+        },
+        "css-what": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
+            "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==",
+            "dev": true
         },
         "cssesc": {
             "version": "0.1.0",
@@ -2451,115 +3290,101 @@
             "dev": true
         },
         "cssnano": {
-            "version": "3.10.0",
-            "resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
-            "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.8.tgz",
+            "integrity": "sha512-5GIY0VzAHORpbKiL3rMXp4w4M1Ki+XlXgEXyuWXVd3h6hlASb+9Vo76dNP56/elLMVBBsUfusCo1q56uW0UWig==",
             "dev": true,
             "requires": {
-                "autoprefixer": "^6.3.1",
-                "decamelize": "^1.1.2",
-                "defined": "^1.0.0",
-                "has": "^1.0.1",
-                "object-assign": "^4.0.1",
-                "postcss": "^5.0.14",
-                "postcss-calc": "^5.2.0",
-                "postcss-colormin": "^2.1.8",
-                "postcss-convert-values": "^2.3.4",
-                "postcss-discard-comments": "^2.0.4",
-                "postcss-discard-duplicates": "^2.0.1",
-                "postcss-discard-empty": "^2.0.1",
-                "postcss-discard-overridden": "^0.1.1",
-                "postcss-discard-unused": "^2.2.1",
-                "postcss-filter-plugins": "^2.0.0",
-                "postcss-merge-idents": "^2.1.5",
-                "postcss-merge-longhand": "^2.0.1",
-                "postcss-merge-rules": "^2.0.3",
-                "postcss-minify-font-values": "^1.0.2",
-                "postcss-minify-gradients": "^1.0.1",
-                "postcss-minify-params": "^1.0.4",
-                "postcss-minify-selectors": "^2.0.4",
-                "postcss-normalize-charset": "^1.1.0",
-                "postcss-normalize-url": "^3.0.7",
-                "postcss-ordered-values": "^2.1.0",
-                "postcss-reduce-idents": "^2.2.2",
-                "postcss-reduce-initial": "^1.0.0",
-                "postcss-reduce-transforms": "^1.0.3",
-                "postcss-svgo": "^2.1.1",
-                "postcss-unique-selectors": "^2.0.2",
-                "postcss-value-parser": "^3.2.3",
-                "postcss-zindex": "^2.0.1"
-            },
-            "dependencies": {
-                "autoprefixer": {
-                    "version": "6.7.7",
-                    "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-                    "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-                    "dev": true,
-                    "requires": {
-                        "browserslist": "^1.7.6",
-                        "caniuse-db": "^1.0.30000634",
-                        "normalize-range": "^0.1.2",
-                        "num2fraction": "^1.2.2",
-                        "postcss": "^5.2.16",
-                        "postcss-value-parser": "^3.2.3"
-                    }
-                },
-                "browserslist": {
-                    "version": "1.7.7",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-                    "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-                    "dev": true,
-                    "requires": {
-                        "caniuse-db": "^1.0.30000639",
-                        "electron-to-chromium": "^1.2.7"
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
+                "cosmiconfig": "^5.0.0",
+                "cssnano-preset-default": "^4.0.6",
+                "is-resolvable": "^1.0.0",
+                "postcss": "^7.0.0"
             }
+        },
+        "cssnano-preset-default": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.6.tgz",
+            "integrity": "sha512-UPboYbFaJFtDUhJ4fqctThWbbyF4q01/7UhsZbLzp35l+nUxtzh1SifoVlEfyLM3n3Z0htd8B1YlCxy9i+bQvg==",
+            "dev": true,
+            "requires": {
+                "css-declaration-sorter": "^4.0.1",
+                "cssnano-util-raw-cache": "^4.0.1",
+                "postcss": "^7.0.0",
+                "postcss-calc": "^7.0.0",
+                "postcss-colormin": "^4.0.2",
+                "postcss-convert-values": "^4.0.1",
+                "postcss-discard-comments": "^4.0.1",
+                "postcss-discard-duplicates": "^4.0.2",
+                "postcss-discard-empty": "^4.0.1",
+                "postcss-discard-overridden": "^4.0.1",
+                "postcss-merge-longhand": "^4.0.10",
+                "postcss-merge-rules": "^4.0.2",
+                "postcss-minify-font-values": "^4.0.2",
+                "postcss-minify-gradients": "^4.0.1",
+                "postcss-minify-params": "^4.0.1",
+                "postcss-minify-selectors": "^4.0.1",
+                "postcss-normalize-charset": "^4.0.1",
+                "postcss-normalize-display-values": "^4.0.1",
+                "postcss-normalize-positions": "^4.0.1",
+                "postcss-normalize-repeat-style": "^4.0.1",
+                "postcss-normalize-string": "^4.0.1",
+                "postcss-normalize-timing-functions": "^4.0.1",
+                "postcss-normalize-unicode": "^4.0.1",
+                "postcss-normalize-url": "^4.0.1",
+                "postcss-normalize-whitespace": "^4.0.1",
+                "postcss-ordered-values": "^4.1.1",
+                "postcss-reduce-initial": "^4.0.2",
+                "postcss-reduce-transforms": "^4.0.1",
+                "postcss-svgo": "^4.0.1",
+                "postcss-unique-selectors": "^4.0.1"
+            }
+        },
+        "cssnano-util-get-arguments": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+            "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
+            "dev": true
+        },
+        "cssnano-util-get-match": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+            "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
+            "dev": true
+        },
+        "cssnano-util-raw-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+            "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
+            "dev": true,
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "cssnano-util-same-parent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+            "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==",
+            "dev": true
         },
         "csso": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
-            "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+            "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
             "dev": true,
             "requires": {
-                "clap": "^1.0.9",
-                "source-map": "^0.5.3"
-            }
-        },
-        "currently-unhandled": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-            "dev": true,
-            "requires": {
-                "array-find-index": "^1.0.1"
+                "css-tree": "1.0.0-alpha.29"
+            },
+            "dependencies": {
+                "css-tree": {
+                    "version": "1.0.0-alpha.29",
+                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+                    "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+                    "dev": true,
+                    "requires": {
+                        "mdn-data": "~1.1.0",
+                        "source-map": "^0.5.3"
+                    }
+                }
             }
         },
         "cyclist": {
@@ -2568,34 +3393,10 @@
             "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
             "dev": true
         },
-        "d": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-            "dev": true,
-            "requires": {
-                "es5-ext": "^0.10.9"
-            }
-        },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
         "date-now": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
             "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-            "dev": true
-        },
-        "de-indent": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-            "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
             "dev": true
         },
         "debug": {
@@ -2624,6 +3425,58 @@
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
             "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
             "dev": true
+        },
+        "deepmerge": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+            "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+            "dev": true
+        },
+        "default-gateway": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
+            "integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+            "dev": true,
+            "requires": {
+                "execa": "^0.10.0",
+                "ip-regex": "^2.1.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+                    "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+                    "dev": true
+                }
+            }
         },
         "define-properties": {
             "version": "1.1.3",
@@ -2675,12 +3528,6 @@
                 }
             }
         },
-        "defined": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-            "dev": true
-        },
         "del": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
@@ -2695,6 +3542,27 @@
                 "rimraf": "^2.2.8"
             },
             "dependencies": {
+                "globby": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+                    "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                            "dev": true
+                        }
+                    }
+                },
                 "pify": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -2702,18 +3570,6 @@
                     "dev": true
                 }
             }
-        },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true
-        },
-        "delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-            "dev": true
         },
         "depd": {
             "version": "1.1.2",
@@ -2737,14 +3593,11 @@
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
             "dev": true
         },
-        "detect-indent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-            "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-            "dev": true,
-            "requires": {
-                "repeating": "^2.0.0"
-            }
+        "detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+            "dev": true
         },
         "detect-node": {
             "version": "2.0.4",
@@ -2760,13 +3613,40 @@
         },
         "diffie-hellman": {
             "version": "5.0.3",
-            "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
                 "miller-rabin": "^4.0.0",
                 "randombytes": "^2.0.0"
+            }
+        },
+        "dir-glob": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+            "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+            "dev": true,
+            "requires": {
+                "arrify": "^1.0.1",
+                "path-type": "^3.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
             }
         },
         "dns-equal": {
@@ -2794,16 +3674,59 @@
                 "buffer-indexof": "^1.0.0"
             }
         },
+        "dom-serializer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                    "dev": true
+                }
+            }
+        },
         "domain-browser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
             "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
             "dev": true
         },
+        "domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "dev": true
+        },
+        "domutils": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+            "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "dot-prop": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+            "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+            "dev": true,
+            "requires": {
+                "is-obj": "^1.0.0"
+            }
+        },
         "dotenv": {
-            "version": "4.0.0",
-            "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-            "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+            "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
             "dev": true
         },
         "dotenv-expand": {
@@ -2813,9 +3736,9 @@
             "dev": true
         },
         "duplexify": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-            "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
             "dev": true,
             "requires": {
                 "end-of-stream": "^1.0.0",
@@ -2842,17 +3765,6 @@
                 "tfunk": "^3.0.1"
             }
         },
-        "ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2860,9 +3772,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.75",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.75.tgz",
-            "integrity": "sha512-nLo03Qpw++8R6BxDZL/B1c8SQvUe/htdgc5LWYHe5YotV2jVvRUMP5AlOmxOsyeOzgMiXrNln2mC05Ixz6vuUQ==",
+            "version": "1.3.113",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
+            "integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==",
             "dev": true
         },
         "elliptic": {
@@ -2902,9 +3814,9 @@
             }
         },
         "engine.io": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
-            "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
+            "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.4",
@@ -2913,12 +3825,25 @@
                 "debug": "~3.1.0",
                 "engine.io-parser": "~2.1.0",
                 "ws": "~3.3.1"
+            },
+            "dependencies": {
+                "ws": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
+                    }
+                }
             }
         },
         "engine.io-client": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-            "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
+            "integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
@@ -2929,35 +3854,40 @@
                 "indexof": "0.0.1",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "ws": "~3.3.1",
+                "ws": "~6.1.0",
                 "xmlhttprequest-ssl": "~1.5.4",
                 "yeast": "0.1.2"
             }
         },
         "engine.io-parser": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-            "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+            "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
             "dev": true,
             "requires": {
                 "after": "0.8.2",
                 "arraybuffer.slice": "~0.0.7",
                 "base64-arraybuffer": "0.1.5",
-                "blob": "0.0.4",
+                "blob": "0.0.5",
                 "has-binary2": "~1.0.2"
             }
         },
         "enhanced-resolve": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
-            "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+            "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "memory-fs": "^0.4.0",
-                "object-assign": "^4.0.1",
-                "tapable": "^0.2.7"
+                "tapable": "^1.0.0"
             }
+        },
+        "entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+            "dev": true
         },
         "errno": {
             "version": "0.1.7",
@@ -2987,16 +3917,17 @@
             }
         },
         "es-abstract": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-            "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+            "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "^1.1.1",
+                "es-to-primitive": "^1.2.0",
                 "function-bind": "^1.1.1",
-                "has": "^1.0.1",
-                "is-callable": "^1.1.3",
-                "is-regex": "^1.0.4"
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
             }
         },
         "es-to-primitive": {
@@ -3010,65 +3941,6 @@
                 "is-symbol": "^1.0.2"
             }
         },
-        "es5-ext": {
-            "version": "0.10.46",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-            "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
-            "dev": true,
-            "requires": {
-                "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.1",
-                "next-tick": "1"
-            }
-        },
-        "es6-iterator": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
-            }
-        },
-        "es6-map": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-            "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14",
-                "es6-iterator": "~2.0.1",
-                "es6-set": "~0.1.5",
-                "es6-symbol": "~3.1.1",
-                "event-emitter": "~0.3.5"
-            }
-        },
-        "es6-set": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-            "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14",
-                "es6-iterator": "~2.0.1",
-                "es6-symbol": "3.1.1",
-                "event-emitter": "~0.3.5"
-            }
-        },
-        "es6-symbol": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
-            }
-        },
         "es6-templates": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
@@ -3077,18 +3949,6 @@
             "requires": {
                 "recast": "~0.11.12",
                 "through": "~2.3.6"
-            }
-        },
-        "es6-weak-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.14",
-                "es6-iterator": "^2.0.1",
-                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -3103,22 +3963,20 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
-        "escope": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-            "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+        "eslint-scope": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+            "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
             "dev": true,
             "requires": {
-                "es6-map": "^0.1.3",
-                "es6-weak-map": "^2.0.1",
                 "esrecurse": "^4.1.0",
                 "estraverse": "^4.1.1"
             }
         },
         "esprima": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+            "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
             "dev": true
         },
         "esrecurse": {
@@ -3148,16 +4006,6 @@
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
             "dev": true
         },
-        "event-emitter": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
-            }
-        },
         "eventemitter3": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -3165,18 +4013,18 @@
             "dev": true
         },
         "events": {
-            "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
-            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+            "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
             "dev": true
         },
         "eventsource": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-            "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+            "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
             "dev": true,
             "requires": {
-                "original": ">=0.0.5"
+                "original": "^1.0.0"
             }
         },
         "evp_bytestokey": {
@@ -3190,18 +4038,33 @@
             }
         },
         "execa": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
             "dev": true,
             "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
                 "is-stream": "^1.1.0",
                 "npm-run-path": "^2.0.0",
                 "p-finally": "^1.0.0",
                 "signal-exit": "^3.0.0",
                 "strip-eof": "^1.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                }
             }
         },
         "expand-brackets": {
@@ -3305,15 +4168,24 @@
                 }
             }
         },
+        "expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1"
+            }
+        },
         "express": {
-            "version": "4.16.3",
-            "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
-            "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+            "version": "4.16.4",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+            "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.5",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.18.2",
+                "body-parser": "1.18.3",
                 "content-disposition": "0.5.2",
                 "content-type": "~1.0.4",
                 "cookie": "0.3.1",
@@ -3330,10 +4202,10 @@
                 "on-finished": "~2.3.0",
                 "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.3",
-                "qs": "6.5.1",
+                "proxy-addr": "~2.0.4",
+                "qs": "6.5.2",
                 "range-parser": "~1.2.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
@@ -3360,7 +4232,7 @@
                 },
                 "finalhandler": {
                     "version": "1.1.1",
-                    "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
                     "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
                     "dev": true,
                     "requires": {
@@ -3374,15 +4246,9 @@
                     }
                 },
                 "qs": {
-                    "version": "6.5.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-                    "dev": true
-                },
-                "safe-buffer": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
                     "dev": true
                 },
                 "statuses": {
@@ -3392,12 +4258,6 @@
                     "dev": true
                 }
             }
-        },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "dev": true
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -3486,15 +4346,15 @@
             }
         },
         "extract-text-webpack-plugin": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
-            "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
+            "version": "4.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-4.0.0-beta.0.tgz",
+            "integrity": "sha512-Hypkn9jUTnFr0DpekNam53X47tXn3ucY08BQumv7kdGgeVUBLq3DJHJTi6HNxv4jl9W+Skxjz9+RnK0sJyqqjA==",
             "dev": true,
             "requires": {
                 "async": "^2.4.1",
                 "loader-utils": "^1.1.0",
-                "schema-utils": "^0.3.0",
-                "webpack-sources": "^1.0.1"
+                "schema-utils": "^0.4.5",
+                "webpack-sources": "^1.1.0"
             },
             "dependencies": {
                 "async": {
@@ -3508,17 +4368,48 @@
                 }
             }
         },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
             "dev": true
         },
-        "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-            "dev": true
+        "fast-glob": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
+            "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
+            "dev": true,
+            "requires": {
+                "@mrmlnc/readdir-enhanced": "^2.2.1",
+                "@nodelib/fs.stat": "^1.1.2",
+                "glob-parent": "^3.1.0",
+                "is-glob": "^4.0.0",
+                "merge2": "^1.2.3",
+                "micromatch": "^3.1.10"
+            },
+            "dependencies": {
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                }
+            }
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
@@ -3527,9 +4418,9 @@
             "dev": true
         },
         "fastparse": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-            "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+            "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
             "dev": true
         },
         "faye-websocket": {
@@ -3541,14 +4432,40 @@
                 "websocket-driver": ">=0.5.1"
             }
         },
+        "figgy-pudding": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+            "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+            "dev": true
+        },
         "file-loader": {
-            "version": "0.11.2",
-            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
-            "integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
+            "integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.0.2"
+                "loader-utils": "^1.0.2",
+                "schema-utils": "^1.0.0"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                }
             }
+        },
+        "file-type": {
+            "version": "10.7.1",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.7.1.tgz",
+            "integrity": "sha512-kUc4EE9q3MH6kx70KumPOvXLZLEJZzY9phEVg/bKWyGZ+OA9KoKZzFR4HS0yDmNv31sJkdf4hbTERIfplF9OxQ==",
+            "dev": true
         },
         "filename-regex": {
             "version": "2.0.1",
@@ -3606,14 +4523,14 @@
             }
         },
         "find-cache-dir": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-            "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+            "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
             "dev": true,
             "requires": {
                 "commondir": "^1.0.1",
                 "make-dir": "^1.0.0",
-                "pkg-dir": "^2.0.0"
+                "pkg-dir": "^3.0.0"
             }
         },
         "find-up": {
@@ -3626,26 +4543,77 @@
                 "pinkie-promise": "^2.0.0"
             }
         },
-        "flatten": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-            "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
-            "dev": true
-        },
-        "flush-write-stream": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-            "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+        "findup-sync": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                }
+            }
+        },
+        "flush-write-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.0.tgz",
+            "integrity": "sha512-6MHED/cmsyux1G4/Cek2Z776y9t7WCNd3h2h/HW91vFeU7pzMhA8XvAlDhHcanG5IWuIh/xcC7JASY4WQpG6xg==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+                    "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
             }
         },
         "follow-redirects": {
-            "version": "1.5.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
-            "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+            "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
             "dev": true,
             "requires": {
                 "debug": "=3.1.0"
@@ -3664,34 +4632,6 @@
             "dev": true,
             "requires": {
                 "for-in": "^1.0.1"
-            }
-        },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "dev": true
-        },
-        "form-data": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-            "dev": true,
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
-            },
-            "dependencies": {
-                "combined-stream": {
-                    "version": "1.0.6",
-                    "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-                    "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-                    "dev": true,
-                    "requires": {
-                        "delayed-stream": "~1.0.0"
-                    }
-                }
             }
         },
         "forwarded": {
@@ -4327,48 +5267,11 @@
                 }
             }
         },
-        "fstream": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-            }
-        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
-        },
-        "gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "dev": true,
-            "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            }
-        },
-        "gaze": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-            "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-            "dev": true,
-            "requires": {
-                "globule": "^1.0.0"
-            }
         },
         "get-caller-file": {
             "version": "1.0.3",
@@ -4376,32 +5279,20 @@
             "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
             "dev": true
         },
-        "get-stdin": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-            "dev": true
-        },
         "get-stream": {
-            "version": "3.0.0",
-            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-            "dev": true
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "dev": true,
+            "requires": {
+                "pump": "^3.0.0"
+            }
         },
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
             "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
             "dev": true
-        },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
         },
         "glob": {
             "version": "7.1.3",
@@ -4474,23 +5365,63 @@
                 }
             }
         },
+        "glob-to-regexp": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+            "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+            "dev": true
+        },
+        "global-modules": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "dev": true,
+            "requires": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+            }
+        },
+        "global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            }
+        },
         "globals": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+            "version": "11.10.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+            "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
             "dev": true
         },
         "globby": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-            "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+            "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
             "dev": true,
             "requires": {
                 "array-union": "^1.0.1",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "dir-glob": "2.0.0",
+                "fast-glob": "^2.0.2",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
             }
         },
         "globs": {
@@ -4500,17 +5431,6 @@
             "dev": true,
             "requires": {
                 "glob": "^7.1.1"
-            }
-        },
-        "globule": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-            "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
-            "dev": true,
-            "requires": {
-                "glob": "~7.1.1",
-                "lodash": "~4.17.10",
-                "minimatch": "~3.0.2"
             }
         },
         "graceful-fs": {
@@ -4526,26 +5446,10 @@
             "dev": true
         },
         "handle-thing": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-            "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
-            "dev": true
-        },
-        "har-schema": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+            "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
             "dev": true
-        },
-        "har-validator": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-            "dev": true,
-            "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
-            }
         },
         "has": {
             "version": "1.0.3",
@@ -4590,12 +5494,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
             "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-            "dev": true
-        },
-        "has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
             "dev": true
         },
         "has-value": {
@@ -4656,9 +5554,9 @@
             "dev": true
         },
         "hash.js": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-            "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
             "dev": true,
             "requires": {
                 "inherits": "^2.0.3",
@@ -4674,9 +5572,15 @@
             }
         },
         "he": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true
+        },
+        "hex-color-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+            "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
             "dev": true
         },
         "hmac-drbg": {
@@ -4690,14 +5594,13 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
-        "home-or-tmp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-            "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+        "homedir-polyfill": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+            "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.1"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -4718,6 +5621,18 @@
                 "wbuf": "^1.1.0"
             }
         },
+        "hsl-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+            "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
+            "dev": true
+        },
+        "hsla-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+            "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
+            "dev": true
+        },
         "html-comment-regex": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
@@ -4731,28 +5646,28 @@
             "dev": true
         },
         "html-loader": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.4.5.tgz",
-            "integrity": "sha1-X7zYfNY6XEmn/OL+VvQl4Fcpxow=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.5.5.tgz",
+            "integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
             "dev": true,
             "requires": {
-                "es6-templates": "^0.2.2",
+                "es6-templates": "^0.2.3",
                 "fastparse": "^1.1.1",
-                "html-minifier": "^3.0.1",
-                "loader-utils": "^1.0.2",
-                "object-assign": "^4.1.0"
+                "html-minifier": "^3.5.8",
+                "loader-utils": "^1.1.0",
+                "object-assign": "^4.1.1"
             }
         },
         "html-minifier": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
-            "integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+            "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
             "dev": true,
             "requires": {
                 "camel-case": "3.0.x",
                 "clean-css": "4.2.x",
                 "commander": "2.17.x",
-                "he": "1.1.x",
+                "he": "1.2.x",
                 "param-case": "2.1.x",
                 "relateurl": "0.2.x",
                 "uglify-js": "3.4.x"
@@ -4763,22 +5678,6 @@
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
                     "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
                     "dev": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "uglify-js": {
-                    "version": "3.4.9",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-                    "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-                    "dev": true,
-                    "requires": {
-                        "commander": "~2.17.1",
-                        "source-map": "~0.6.1"
-                    }
                 }
             }
         },
@@ -4809,9 +5708,9 @@
             }
         },
         "http-parser-js": {
-            "version": "0.4.13",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
-            "integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
+            "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==",
             "dev": true
         },
         "http-proxy": {
@@ -4825,15 +5724,15 @@
             }
         },
         "http-proxy-middleware": {
-            "version": "0.17.4",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
-            "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+            "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
             "dev": true,
             "requires": {
                 "http-proxy": "^1.16.2",
-                "is-glob": "^3.1.0",
-                "lodash": "^4.17.2",
-                "micromatch": "^2.3.11"
+                "is-glob": "^4.0.0",
+                "lodash": "^4.17.5",
+                "micromatch": "^3.1.9"
             },
             "dependencies": {
                 "eventemitter3": {
@@ -4853,26 +5752,27 @@
                         "requires-port": "^1.0.0"
                     }
                 },
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.0"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
-            }
-        },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
             }
         },
         "https-browserify": {
@@ -4903,6 +5803,54 @@
             "dev": true,
             "requires": {
                 "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "ieee754": {
@@ -4917,10 +5865,38 @@
             "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
             "dev": true
         },
+        "ignore": {
+            "version": "3.3.10",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+            "dev": true
+        },
+        "imagemin": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-6.1.0.tgz",
+            "integrity": "sha512-8ryJBL1CN5uSHpiBMX0rJw79C9F9aJqMnjGnrd/1CafegpNuA81RBAAru/jQQEOWlOJJlpRnlcVFF6wq+Ist0A==",
+            "dev": true,
+            "requires": {
+                "file-type": "^10.7.0",
+                "globby": "^8.0.1",
+                "make-dir": "^1.0.0",
+                "p-pipe": "^1.1.0",
+                "pify": "^4.0.1",
+                "replace-ext": "^1.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                }
+            }
+        },
         "img-loader": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/img-loader/-/img-loader-3.0.0.tgz",
-            "integrity": "sha512-2TuWF+qS5zcXPbE+w1Yoquizy4slmEKmAlAuNlRAvzZ1F9JK2wkbtx8FfkIxBqEr56cbLiT2Xg2HgPt03SgrjQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/img-loader/-/img-loader-3.0.1.tgz",
+            "integrity": "sha512-0jDJqexgzOuq3zlXwFTBKJlMcaP1uXyl5t4Qu6b1IgXb3IwBDjPfVylBC8vHFIIESDw/S+5QkBbtBrt4T8wESA==",
             "dev": true,
             "requires": {
                 "loader-utils": "^1.1.0"
@@ -4941,6 +5917,16 @@
                 "import-from": "^2.1.0"
             }
         },
+        "import-fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+            "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+            "dev": true,
+            "requires": {
+                "caller-path": "^2.0.0",
+                "resolve-from": "^3.0.0"
+            }
+        },
         "import-from": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
@@ -4951,12 +5937,12 @@
             }
         },
         "import-local": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-            "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+            "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0",
                 "resolve-cwd": "^2.0.0"
             }
         },
@@ -4965,21 +5951,6 @@
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
-        },
-        "in-publish": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-            "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
-            "dev": true
-        },
-        "indent-string": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-            "dev": true,
-            "requires": {
-                "repeating": "^2.0.0"
-            }
         },
         "indexes-of": {
             "version": "1.0.1",
@@ -5009,19 +5980,26 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
             "dev": true
         },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
+        },
         "internal-ip": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
-            "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
+            "integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
             "dev": true,
             "requires": {
-                "meow": "^3.3.0"
+                "default-gateway": "^2.6.0",
+                "ipaddr.js": "^1.5.2"
             }
         },
         "interpret": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
             "dev": true
         },
         "invariant": {
@@ -5043,6 +6021,12 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
             "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "dev": true
+        },
+        "ip-regex": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
             "dev": true
         },
         "ipaddr.js": {
@@ -5112,6 +6096,20 @@
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
             "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
             "dev": true
+        },
+        "is-color-stop": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
+            "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+            "dev": true,
+            "requires": {
+                "css-color-names": "^0.0.4",
+                "hex-color-regex": "^1.1.0",
+                "hsl-regex": "^1.0.0",
+                "hsla-regex": "^1.0.0",
+                "rgb-regex": "^1.0.1",
+                "rgba-regex": "^1.0.0"
+            }
         },
         "is-data-descriptor": {
             "version": "0.1.4",
@@ -5191,15 +6189,6 @@
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
         },
-        "is-finite": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-            "dev": true,
-            "requires": {
-                "number-is-nan": "^1.0.0"
-            }
-        },
         "is-fullwidth-code-point": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -5247,6 +6236,12 @@
                 "lodash.isfinite": "^3.3.2"
             }
         },
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
         "is-path-cwd": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -5270,12 +6265,6 @@
             "requires": {
                 "path-is-inside": "^1.0.1"
             }
-        },
-        "is-plain-obj": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -5307,6 +6296,12 @@
                 "has": "^1.0.1"
             }
         },
+        "is-resolvable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+            "dev": true
+        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -5314,9 +6309,9 @@
             "dev": true
         },
         "is-svg": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
-            "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+            "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
             "dev": true,
             "requires": {
                 "html-comment-regex": "^1.1.0"
@@ -5330,12 +6325,6 @@
             "requires": {
                 "has-symbols": "^1.0.0"
             }
-        },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
         },
         "is-utf8": {
             "version": "0.2.1",
@@ -5373,51 +6362,40 @@
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
             "dev": true
         },
-        "isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-            "dev": true
-        },
-        "js-base64": {
-            "version": "2.4.9",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
-            "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==",
+        "js-levenshtein": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
             "dev": true
         },
         "js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
         },
         "js-yaml": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-            "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+            "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
-                "esprima": "^2.6.0"
+                "esprima": "^4.0.0"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+                    "dev": true
+                }
             }
         },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true,
-            "optional": true
-        },
         "jsesc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-            "dev": true
-        },
-        "json-loader": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-            "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true
         },
         "json-parse-better-errors": {
@@ -5426,22 +6404,10 @@
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "dev": true
         },
-        "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-            "dev": true
-        },
         "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-            "dev": true
-        },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
         "json3": {
@@ -5451,10 +6417,13 @@
             "dev": true
         },
         "json5": {
-            "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-            "dev": true
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+            "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.0"
+            }
         },
         "jsonfile": {
             "version": "3.0.1",
@@ -5463,18 +6432,6 @@
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
             }
         },
         "killable": {
@@ -5490,47 +6447,47 @@
             "dev": true
         },
         "laravel-mix": {
-            "version": "2.1.14",
-            "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-2.1.14.tgz",
-            "integrity": "sha512-M/Vzgr6+QQGukciAQ91SZvOhUyrPm41bq/nRyF2j2HR8/g3vzvTQbRkdTGOpq9Z+y3REEj8qR2A3ScnEG37Dgw==",
+            "version": "4.0.14",
+            "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-4.0.14.tgz",
+            "integrity": "sha512-YvUl9LCn3n6jiJvoybahIcOgBVcsWM1ju5RWTtioXb4JkoNHQq0iHPR/eJVlqQpLVTZlvaJjbb9HsCylpZrDxQ==",
             "dev": true,
             "requires": {
-                "autoprefixer": "^7.2.6",
-                "babel-core": "^6.24.1",
-                "babel-loader": "^7.1.1",
-                "babel-plugin-transform-object-rest-spread": "^6.26.0",
-                "babel-plugin-transform-runtime": "^6.23.0",
-                "babel-preset-env": "^1.5.1",
+                "@babel/core": "^7.2.0",
+                "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
+                "@babel/plugin-transform-runtime": "^7.2.0",
+                "@babel/preset-env": "^7.2.0",
+                "@babel/runtime": "^7.2.0",
+                "autoprefixer": "^9.4.2",
+                "babel-loader": "^8.0.4",
+                "babel-merge": "^2.0.1",
                 "chokidar": "^2.0.3",
                 "clean-css": "^4.1.3",
                 "concatenate": "0.0.2",
-                "css-loader": "^0.28.9",
-                "dotenv": "^4.0.0",
+                "css-loader": "^1.0.1",
+                "dotenv": "^6.2.0",
                 "dotenv-expand": "^4.2.0",
-                "extract-text-webpack-plugin": "^3.0.2",
-                "file-loader": "^0.11.2",
+                "extract-text-webpack-plugin": "v4.0.0-beta.0",
+                "file-loader": "^2.0.0",
                 "friendly-errors-webpack-plugin": "^1.6.1",
-                "fs-extra": "^3.0.1",
+                "fs-extra": "^7.0.1",
                 "glob": "^7.1.2",
-                "html-loader": "^0.4.5",
+                "html-loader": "^0.5.5",
+                "imagemin": "^6.0.0",
                 "img-loader": "^3.0.0",
                 "lodash": "^4.17.5",
                 "md5": "^2.2.1",
-                "node-sass": "^4.9.0",
-                "postcss-loader": "^2.1.0",
-                "resolve-url-loader": "^2.2.1",
-                "sass-loader": "^6.0.5",
-                "style-loader": "^0.18.2",
-                "uglify-js": "^2.8.29",
-                "uglifyjs-webpack-plugin": "^1.1.8",
-                "vue-loader": "^13.7.1",
-                "vue-template-compiler": "^2.5.13",
-                "webpack": "^3.11.0",
-                "webpack-chunk-hash": "^0.4.0",
-                "webpack-dev-server": "^2.11.1",
+                "optimize-css-assets-webpack-plugin": "^5.0.1",
+                "postcss-loader": "^3.0.0",
+                "style-loader": "^0.23.1",
+                "terser": "^3.11.0",
+                "terser-webpack-plugin": "^1.1.0",
+                "vue-loader": "^15.4.2",
+                "webpack": "^4.27.1",
+                "webpack-cli": "^3.1.2",
+                "webpack-dev-server": "^3.1.14",
                 "webpack-merge": "^4.1.0",
                 "webpack-notifier": "^1.5.1",
-                "yargs": "^8.0.2"
+                "yargs": "^12.0.5"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -5540,19 +6497,47 @@
                     "dev": true
                 },
                 "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+                    "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
                     "dev": true
                 },
-                "find-up": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                "cliui": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "fs-extra": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+                    "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
@@ -5560,57 +6545,33 @@
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
-                "load-json-file": {
-                    "version": "2.0.0",
-                    "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-                    "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+                "jsonfile": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "strip-bom": "^3.0.0"
+                        "graceful-fs": "^4.1.6"
+                    }
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
                     }
                 },
                 "os-locale": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-                    "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
-                    }
-                },
-                "path-type": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-                    "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-                    "dev": true,
-                    "requires": {
-                        "pify": "^2.0.0"
-                    }
-                },
-                "read-pkg": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-                    "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-                    "dev": true,
-                    "requires": {
-                        "load-json-file": "^2.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^2.0.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-                    "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^2.0.0",
-                        "read-pkg": "^2.0.0"
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
                     }
                 },
                 "string-width": {
@@ -5632,12 +6593,6 @@
                         "ansi-regex": "^3.0.0"
                     }
                 },
-                "strip-bom": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-                    "dev": true
-                },
                 "which-module": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -5645,42 +6600,46 @@
                     "dev": true
                 },
                 "yargs": {
-                    "version": "8.0.2",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-                    "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+                    "version": "12.0.5",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
                         "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
-                        "read-pkg-up": "^2.0.0",
+                        "os-locale": "^3.0.0",
                         "require-directory": "^2.1.1",
                         "require-main-filename": "^1.0.1",
                         "set-blocking": "^2.0.0",
                         "string-width": "^2.0.0",
                         "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^7.0.0"
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
                     }
                 },
                 "yargs-parser": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-                    "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+                    "version": "11.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
                     }
                 }
             }
         },
-        "lazy-cache": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-            "dev": true
+        "last-call-webpack-plugin": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
+            "integrity": "sha512-7KI2l2GIZa9p2spzPIVZBYyNKkN+e/SQPpnjlTiPhdbDW3F86tdKKELxKpzJ5sgU19wQWsACULZmpTPYHeWO5w==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.5",
+                "webpack-sources": "^1.1.0"
+            }
         },
         "lcid": {
             "version": "1.0.0",
@@ -5692,9 +6651,9 @@
             }
         },
         "limiter": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
-            "integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.4.tgz",
+            "integrity": "sha512-XCpr5bElgDI65vVgstP8TWjv6/QKWm9GU5UG0Pr5sLQ3QLo8NVKsioe+Jed5/3vFOe3IQuqE7DKwTvKQkjTHvg==",
             "dev": true
         },
         "load-json-file": {
@@ -5711,20 +6670,31 @@
             }
         },
         "loader-runner": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
-            "integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+            "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
             "dev": true
         },
         "loader-utils": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-            "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+            "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
             "dev": true,
             "requires": {
-                "big.js": "^3.1.3",
+                "big.js": "^5.2.2",
                 "emojis-list": "^2.0.0",
-                "json5": "^0.5.0"
+                "json5": "^1.0.1"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                }
             }
         },
         "localtunnel": {
@@ -5739,16 +6709,6 @@
                 "yargs": "6.6.0"
             },
             "dependencies": {
-                "axios": {
-                    "version": "0.17.1",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-                    "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-                    "dev": true,
-                    "requires": {
-                        "follow-redirects": "^1.2.5",
-                        "is-buffer": "^1.1.5"
-                    }
-                },
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5782,12 +6742,12 @@
             }
         },
         "locate-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
             "dev": true,
             "requires": {
-                "p-locate": "^2.0.0",
+                "p-locate": "^3.0.0",
                 "path-exists": "^3.0.0"
             },
             "dependencies": {
@@ -5804,67 +6764,10 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
             "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
-        "lodash._baseassign": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-            "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-            "dev": true,
-            "requires": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash.keys": "^3.0.0"
-            }
-        },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-            "dev": true
-        },
-        "lodash._bindcallback": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-            "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-            "dev": true
-        },
-        "lodash._createassigner": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-            "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-            "dev": true,
-            "requires": {
-                "lodash._bindcallback": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash.restparam": "^3.0.0"
-            }
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-            "dev": true
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-            "dev": true
-        },
         "lodash.assign": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
             "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-            "dev": true
-        },
-        "lodash.camelcase": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-            "dev": true
-        },
-        "lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
             "dev": true
         },
         "lodash.debounce": {
@@ -5873,63 +6776,16 @@
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
             "dev": true
         },
-        "lodash.defaults": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-            "dev": true
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-            "dev": true
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-            "dev": true
-        },
         "lodash.isfinite": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
             "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
             "dev": true
         },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true,
-            "requires": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
-            }
-        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-            "dev": true
-        },
-        "lodash.mergewith": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-            "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
-            "dev": true
-        },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-            "dev": true
-        },
-        "lodash.tail": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
-            "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
             "dev": true
         },
         "lodash.uniq": {
@@ -5944,12 +6800,6 @@
             "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
             "dev": true
         },
-        "longest": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-            "dev": true
-        },
         "loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5957,16 +6807,6 @@
             "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
-            }
-        },
-        "loud-rejection": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-            "dev": true,
-            "requires": {
-                "currently-unhandled": "^0.4.1",
-                "signal-exit": "^3.0.0"
             }
         },
         "lower-case": {
@@ -6002,16 +6842,19 @@
                 }
             }
         },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
+            }
+        },
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
             "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-            "dev": true
-        },
-        "map-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
         },
         "map-visit": {
@@ -6022,12 +6865,6 @@
             "requires": {
                 "object-visit": "^1.0.0"
             }
-        },
-        "math-expression-evaluator": {
-            "version": "1.2.17",
-            "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-            "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
-            "dev": true
         },
         "math-random": {
             "version": "1.0.1",
@@ -6057,6 +6894,12 @@
                 "safe-buffer": "^5.1.2"
             }
         },
+        "mdn-data": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+            "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+            "dev": true
+        },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6064,12 +6907,14 @@
             "dev": true
         },
         "mem": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+            "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^1.0.0",
+                "p-is-promise": "^2.0.0"
             }
         },
         "memory-fs": {
@@ -6082,36 +6927,33 @@
                 "readable-stream": "^2.0.1"
             }
         },
-        "meow": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-            "dev": true,
-            "requires": {
-                "camelcase-keys": "^2.0.0",
-                "decamelize": "^1.1.2",
-                "loud-rejection": "^1.0.0",
-                "map-obj": "^1.0.1",
-                "minimist": "^1.1.3",
-                "normalize-package-data": "^2.3.4",
-                "object-assign": "^4.0.1",
-                "read-pkg-up": "^1.0.1",
-                "redent": "^1.0.0",
-                "trim-newlines": "^1.0.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
-            }
-        },
         "merge-descriptors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
             "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
+        "merge-source-map": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+            "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+            "dev": true,
+            "requires": {
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "merge2": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+            "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
             "dev": true
         },
         "methods": {
@@ -6228,18 +7070,18 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.36.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-            "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.20",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-            "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+            "version": "2.1.21",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.36.0"
+                "mime-db": "~1.37.0"
             }
         },
         "mimic-fn": {
@@ -6270,15 +7112,15 @@
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
             "dev": true
         },
         "mississippi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-            "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+            "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
             "dev": true,
             "requires": {
                 "concat-stream": "^1.5.0",
@@ -6287,7 +7129,7 @@
                 "flush-write-stream": "^1.0.0",
                 "from2": "^2.1.0",
                 "parallel-transform": "^1.1.0",
-                "pump": "^2.0.1",
+                "pump": "^3.0.0",
                 "pumpify": "^1.3.3",
                 "stream-each": "^1.1.0",
                 "through2": "^2.0.0"
@@ -6320,31 +7162,21 @@
                 }
             }
         },
-        "mixin-object": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-            "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-            "dev": true,
-            "requires": {
-                "for-in": "^0.1.3",
-                "is-extendable": "^0.1.1"
-            },
-            "dependencies": {
-                "for-in": {
-                    "version": "0.1.8",
-                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-                    "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
-                    "dev": true
-                }
-            }
-        },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
                 "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
             }
         },
         "move-concurrently": {
@@ -6387,7 +7219,8 @@
             "version": "2.11.1",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
             "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -6415,15 +7248,15 @@
             "dev": true
         },
         "neo-async": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.2.tgz",
-            "integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+            "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
             "dev": true
         },
-        "next-tick": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
         },
         "no-case": {
@@ -6447,38 +7280,10 @@
             "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
             "dev": true
         },
-        "node-gyp": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-            "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-            "dev": true,
-            "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "^2.87.0",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-                    "dev": true
-                }
-            }
-        },
         "node-libs-browser": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-            "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
+            "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
             "dev": true,
             "requires": {
                 "assert": "^1.1.1",
@@ -6488,7 +7293,7 @@
                 "constants-browserify": "^1.0.0",
                 "crypto-browserify": "^3.11.0",
                 "domain-browser": "^1.1.1",
-                "events": "^1.0.0",
+                "events": "^3.0.0",
                 "https-browserify": "^1.0.0",
                 "os-browserify": "^0.3.0",
                 "path-browserify": "0.0.0",
@@ -6502,68 +7307,47 @@
                 "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.0",
                 "url": "^0.11.0",
-                "util": "^0.10.3",
+                "util": "^0.11.0",
                 "vm-browserify": "0.0.4"
-            }
-        },
-        "node-notifier": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-            "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
-            "dev": true,
-            "requires": {
-                "growly": "^1.3.0",
-                "semver": "^5.4.1",
-                "shellwords": "^0.1.1",
-                "which": "^1.3.0"
-            }
-        },
-        "node-sass": {
-            "version": "4.9.3",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
-            "integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
-            "dev": true,
-            "requires": {
-                "async-foreach": "^0.1.3",
-                "chalk": "^1.1.1",
-                "cross-spawn": "^3.0.0",
-                "gaze": "^1.0.0",
-                "get-stdin": "^4.0.1",
-                "glob": "^7.0.3",
-                "in-publish": "^2.0.0",
-                "lodash.assign": "^4.2.0",
-                "lodash.clonedeep": "^4.3.2",
-                "lodash.mergewith": "^4.6.0",
-                "meow": "^3.7.0",
-                "mkdirp": "^0.5.1",
-                "nan": "^2.10.0",
-                "node-gyp": "^3.8.0",
-                "npmlog": "^4.0.0",
-                "request": "2.87.0",
-                "sass-graph": "^2.2.4",
-                "stdout-stream": "^1.4.0",
-                "true-case-path": "^1.0.2"
             },
             "dependencies": {
-                "cross-spawn": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-                    "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                },
+                "util": {
+                    "version": "0.11.1",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+                    "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "which": "^1.2.9"
+                        "inherits": "2.0.3"
                     }
                 }
             }
         },
-        "nopt": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+        "node-notifier": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
             "dev": true,
             "requires": {
-                "abbrev": "1"
+                "growly": "^1.3.0",
+                "is-wsl": "^1.1.0",
+                "semver": "^5.5.0",
+                "shellwords": "^0.1.1",
+                "which": "^1.3.0"
+            }
+        },
+        "node-releases": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.7.tgz",
+            "integrity": "sha512-bKdrwaqJUPHqlCzDD7so/R+Nk0jGv9a11ZhLrD9f6i947qGLrGAhU3OxRENa19QQmwzGy/g6zCDEuLGDO8HPvA==",
+            "dev": true,
+            "requires": {
+                "semver": "^5.3.0"
             }
         },
         "normalize-package-data": {
@@ -6594,16 +7378,10 @@
             "dev": true
         },
         "normalize-url": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-            "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-            "dev": true,
-            "requires": {
-                "object-assign": "^4.0.1",
-                "prepend-http": "^1.0.0",
-                "query-string": "^4.1.0",
-                "sort-keys": "^1.0.0"
-            }
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+            "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+            "dev": true
         },
         "npm-run-path": {
             "version": "2.0.2",
@@ -6614,16 +7392,13 @@
                 "path-key": "^2.0.0"
             }
         },
-        "npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+        "nth-check": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
             "dev": true,
             "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "num2fraction": {
@@ -6636,12 +7411,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
-        },
-        "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
             "dev": true
         },
         "object-assign": {
@@ -6708,6 +7477,16 @@
                 "isobject": "^3.0.0"
             }
         },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
+            }
+        },
         "object.omit": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -6725,6 +7504,18 @@
             "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
+            }
+        },
+        "object.values": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+            "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.12.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
             }
         },
         "obuf": {
@@ -6778,6 +7569,16 @@
                 "is-wsl": "^1.1.0"
             }
         },
+        "optimize-css-assets-webpack-plugin": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz",
+            "integrity": "sha512-Rqm6sSjWtx9FchdP0uzTQDc7GXDKnwVEGoSxjezPkzMewx7gEWE9IMUYKmigTRC4U3RaNSwYVnUDLuIdtTpm0A==",
+            "dev": true,
+            "requires": {
+                "cssnano": "^4.1.0",
+                "last-call-webpack-plugin": "^3.0.0"
+            }
+        },
         "original": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -6793,12 +7594,6 @@
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
         },
-        "os-homedir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-            "dev": true
-        },
         "os-locale": {
             "version": "1.4.0",
             "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -6808,21 +7603,11 @@
                 "lcid": "^1.0.0"
             }
         },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
             "dev": true
-        },
-        "osenv": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-            "dev": true,
-            "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-            }
         },
         "p-finally": {
             "version": "1.0.0",
@@ -6830,22 +7615,28 @@
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
             "dev": true
         },
+        "p-is-promise": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+            "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+            "dev": true
+        },
         "p-limit": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+            "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
             "dev": true,
             "requires": {
-                "p-try": "^1.0.0"
+                "p-try": "^2.0.0"
             }
         },
         "p-locate": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
             "dev": true,
             "requires": {
-                "p-limit": "^1.1.0"
+                "p-limit": "^2.0.0"
             }
         },
         "p-map": {
@@ -6854,16 +7645,22 @@
             "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
             "dev": true
         },
+        "p-pipe": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
+            "integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k=",
+            "dev": true
+        },
         "p-try": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+            "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
             "dev": true
         },
         "pako": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
+            "integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==",
             "dev": true
         },
         "parallel-transform": {
@@ -6887,16 +7684,17 @@
             }
         },
         "parse-asn1": {
-            "version": "5.1.1",
-            "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
-            "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
+            "integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
             "dev": true,
             "requires": {
                 "asn1.js": "^4.0.0",
                 "browserify-aes": "^1.0.0",
                 "create-hash": "^1.1.0",
                 "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3"
+                "pbkdf2": "^3.0.3",
+                "safe-buffer": "^5.1.1"
             }
         },
         "parse-glob": {
@@ -6936,6 +7734,12 @@
             "requires": {
                 "error-ex": "^1.2.0"
             }
+        },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
         },
         "parseqs": {
             "version": "0.0.5",
@@ -7052,12 +7856,6 @@
                 "sha.js": "^2.4.8"
             }
         },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-            "dev": true
-        },
         "pify": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -7080,29 +7878,29 @@
             }
         },
         "pkg-dir": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-            "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+            "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
             "dev": true,
             "requires": {
-                "find-up": "^2.1.0"
+                "find-up": "^3.0.0"
             },
             "dependencies": {
                 "find-up": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "^3.0.0"
                     }
                 }
             }
         },
         "portfinder": {
-            "version": "1.0.17",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
-            "integrity": "sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==",
+            "version": "1.0.20",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+            "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
             "dev": true,
             "requires": {
                 "async": "^1.5.2",
@@ -7138,14 +7936,14 @@
             "dev": true
         },
         "postcss": {
-            "version": "6.0.23",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-            "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+            "version": "7.0.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+            "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
+                "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
+                "supports-color": "^6.1.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -7158,14 +7956,312 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "^3.2.1",
                         "escape-string-regexp": "^1.0.5",
                         "supports-color": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-calc": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
+            "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
+            "dev": true,
+            "requires": {
+                "css-unit-converter": "^1.1.1",
+                "postcss": "^7.0.5",
+                "postcss-selector-parser": "^5.0.0-rc.4",
+                "postcss-value-parser": "^3.3.1"
+            }
+        },
+        "postcss-colormin": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.2.tgz",
+            "integrity": "sha512-1QJc2coIehnVFsz0otges8kQLsryi4lo19WD+U5xCWvXd0uw/Z+KKYnbiNDCnO9GP+PvErPHCG0jNvWTngk9Rw==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.0.0",
+                "color": "^3.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            }
+        },
+        "postcss-convert-values": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+            "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            }
+        },
+        "postcss-discard-comments": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.1.tgz",
+            "integrity": "sha512-Ay+rZu1Sz6g8IdzRjUgG2NafSNpp2MSMOQUb+9kkzzzP+kh07fP0yNbhtFejURnyVXSX3FYy2nVNW1QTnNjgBQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-discard-duplicates": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+            "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-discard-empty": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+            "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
+            "dev": true,
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-discard-overridden": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+            "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
+            "dev": true,
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-load-config": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
+            "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
+            "dev": true,
+            "requires": {
+                "cosmiconfig": "^4.0.0",
+                "import-cwd": "^2.0.0"
+            },
+            "dependencies": {
+                "cosmiconfig": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+                    "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-directory": "^0.3.1",
+                        "js-yaml": "^3.9.0",
+                        "parse-json": "^4.0.0",
+                        "require-from-string": "^2.0.1"
+                    }
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-loader": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
+            "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.1.0",
+                "postcss": "^7.0.0",
+                "postcss-load-config": "^2.0.0",
+                "schema-utils": "^1.0.0"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                }
+            }
+        },
+        "postcss-merge-longhand": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.10.tgz",
+            "integrity": "sha512-hME10s6CSjm9nlVIcO1ukR7Jr5RisTaaC1y83jWCivpuBtPohA3pZE7cGTIVSYjXvLnXozHTiVOkG4dnnl756g==",
+            "dev": true,
+            "requires": {
+                "css-color-names": "0.0.4",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0",
+                "stylehacks": "^4.0.0"
+            }
+        },
+        "postcss-merge-rules": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.2.tgz",
+            "integrity": "sha512-UiuXwCCJtQy9tAIxsnurfF0mrNHKc4NnNx6NxqmzNNjXpQwLSukUxELHTRF0Rg1pAmcoKLih8PwvZbiordchag==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.0.0",
+                "caniuse-api": "^3.0.0",
+                "cssnano-util-same-parent": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-selector-parser": "^3.0.0",
+                "vendors": "^1.0.0"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "^4.1.1",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-minify-font-values": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+            "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
+            "dev": true,
+            "requires": {
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            }
+        },
+        "postcss-minify-gradients": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.1.tgz",
+            "integrity": "sha512-pySEW3E6Ly5mHm18rekbWiAjVi/Wj8KKt2vwSfVFAWdW6wOIekgqxKxLU7vJfb107o3FDNPkaYFCxGAJBFyogA==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-arguments": "^4.0.0",
+                "is-color-stop": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            }
+        },
+        "postcss-minify-params": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.1.tgz",
+            "integrity": "sha512-h4W0FEMEzBLxpxIVelRtMheskOKKp52ND6rJv+nBS33G1twu2tCyurYj/YtgU76+UDCvWeNs0hs8HFAWE2OUFg==",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "^1.0.0",
+                "browserslist": "^4.0.0",
+                "cssnano-util-get-arguments": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0",
+                "uniqs": "^2.0.0"
+            }
+        },
+        "postcss-minify-selectors": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.1.tgz",
+            "integrity": "sha512-8+plQkomve3G+CodLCgbhAKrb5lekAnLYuL1d7Nz+/7RANpBEVdgBkPNwljfSKvZ9xkkZTZITd04KP+zeJTJqg==",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "^1.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-selector-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "^4.1.1",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-modules-extract-imports": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+            "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+            "dev": true,
+            "requires": {
+                "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
                     }
                 },
                 "source-map": {
@@ -7185,796 +8281,6 @@
                 }
             }
         },
-        "postcss-calc": {
-            "version": "5.3.1",
-            "resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
-            "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.2",
-                "postcss-message-helpers": "^2.0.0",
-                "reduce-css-calc": "^1.2.6"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-colormin": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
-            "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-            "dev": true,
-            "requires": {
-                "colormin": "^1.0.5",
-                "postcss": "^5.0.13",
-                "postcss-value-parser": "^3.2.3"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-convert-values": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
-            "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.11",
-                "postcss-value-parser": "^3.1.2"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-discard-comments": {
-            "version": "2.0.4",
-            "resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
-            "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.14"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-discard-duplicates": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
-            "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.4"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-discard-empty": {
-            "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
-            "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.14"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-discard-overridden": {
-            "version": "0.1.1",
-            "resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
-            "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.16"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-discard-unused": {
-            "version": "2.2.3",
-            "resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
-            "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.14",
-                "uniqs": "^2.0.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-filter-plugins": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
-            "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.4"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-load-config": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
-            "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
-            "dev": true,
-            "requires": {
-                "cosmiconfig": "^4.0.0",
-                "import-cwd": "^2.0.0"
-            }
-        },
-        "postcss-load-options": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
-            "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-            "dev": true,
-            "requires": {
-                "cosmiconfig": "^2.1.0",
-                "object-assign": "^4.1.0"
-            },
-            "dependencies": {
-                "cosmiconfig": {
-                    "version": "2.2.2",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-                    "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-                    "dev": true,
-                    "requires": {
-                        "is-directory": "^0.3.1",
-                        "js-yaml": "^3.4.3",
-                        "minimist": "^1.2.0",
-                        "object-assign": "^4.1.0",
-                        "os-homedir": "^1.0.1",
-                        "parse-json": "^2.2.0",
-                        "require-from-string": "^1.1.0"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "require-from-string": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-                    "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-                    "dev": true
-                }
-            }
-        },
-        "postcss-load-plugins": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
-            "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-            "dev": true,
-            "requires": {
-                "cosmiconfig": "^2.1.1",
-                "object-assign": "^4.1.0"
-            },
-            "dependencies": {
-                "cosmiconfig": {
-                    "version": "2.2.2",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-                    "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-                    "dev": true,
-                    "requires": {
-                        "is-directory": "^0.3.1",
-                        "js-yaml": "^3.4.3",
-                        "minimist": "^1.2.0",
-                        "object-assign": "^4.1.0",
-                        "os-homedir": "^1.0.1",
-                        "parse-json": "^2.2.0",
-                        "require-from-string": "^1.1.0"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "require-from-string": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-                    "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-                    "dev": true
-                }
-            }
-        },
-        "postcss-loader": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.6.tgz",
-            "integrity": "sha512-hgiWSc13xVQAq25cVw80CH0l49ZKlAnU1hKPOdRrNj89bokRr/bZF2nT+hebPPF9c9xs8c3gw3Fr2nxtmXYnNg==",
-            "dev": true,
-            "requires": {
-                "loader-utils": "^1.1.0",
-                "postcss": "^6.0.0",
-                "postcss-load-config": "^2.0.0",
-                "schema-utils": "^0.4.0"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "6.5.4",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-                    "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-                    "dev": true
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-                    "dev": true
-                },
-                "schema-utils": {
-                    "version": "0.4.7",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-                    "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-keywords": "^3.1.0"
-                    }
-                }
-            }
-        },
-        "postcss-merge-idents": {
-            "version": "2.1.7",
-            "resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
-            "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-            "dev": true,
-            "requires": {
-                "has": "^1.0.1",
-                "postcss": "^5.0.10",
-                "postcss-value-parser": "^3.1.1"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-merge-longhand": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
-            "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.4"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-merge-rules": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
-            "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-            "dev": true,
-            "requires": {
-                "browserslist": "^1.5.2",
-                "caniuse-api": "^1.5.2",
-                "postcss": "^5.0.4",
-                "postcss-selector-parser": "^2.2.2",
-                "vendors": "^1.0.0"
-            },
-            "dependencies": {
-                "browserslist": {
-                    "version": "1.7.7",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-                    "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-                    "dev": true,
-                    "requires": {
-                        "caniuse-db": "^1.0.30000639",
-                        "electron-to-chromium": "^1.2.7"
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-message-helpers": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-            "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
-            "dev": true
-        },
-        "postcss-minify-font-values": {
-            "version": "1.0.5",
-            "resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
-            "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-            "dev": true,
-            "requires": {
-                "object-assign": "^4.0.1",
-                "postcss": "^5.0.4",
-                "postcss-value-parser": "^3.0.2"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-minify-gradients": {
-            "version": "1.0.5",
-            "resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
-            "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.12",
-                "postcss-value-parser": "^3.3.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-minify-params": {
-            "version": "1.2.2",
-            "resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
-            "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-            "dev": true,
-            "requires": {
-                "alphanum-sort": "^1.0.1",
-                "postcss": "^5.0.2",
-                "postcss-value-parser": "^3.0.2",
-                "uniqs": "^2.0.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-minify-selectors": {
-            "version": "2.1.1",
-            "resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
-            "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-            "dev": true,
-            "requires": {
-                "alphanum-sort": "^1.0.2",
-                "has": "^1.0.1",
-                "postcss": "^5.0.14",
-                "postcss-selector-parser": "^2.0.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-modules-extract-imports": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
-            "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
-            "dev": true,
-            "requires": {
-                "postcss": "^6.0.1"
-            }
-        },
         "postcss-modules-local-by-default": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
@@ -7983,6 +8289,54 @@
             "requires": {
                 "css-selector-tokenizer": "^0.7.0",
                 "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "postcss-modules-scope": {
@@ -7993,6 +8347,54 @@
             "requires": {
                 "css-selector-tokenizer": "^0.7.0",
                 "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "postcss-modules-values": {
@@ -8003,385 +8405,236 @@
             "requires": {
                 "icss-replace-symbols": "^1.1.0",
                 "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "postcss-normalize-charset": {
-            "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
-            "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+            "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
             "dev": true,
             "requires": {
-                "postcss": "^5.0.5"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-normalize-display-values": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
+            "integrity": "sha512-R5mC4vaDdvsrku96yXP7zak+O3Mm9Y8IslUobk7IMP+u/g+lXvcN4jngmHY5zeJnrQvE13dfAg5ViU05ZFDwdg==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-match": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            }
+        },
+        "postcss-normalize-positions": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.1.tgz",
+            "integrity": "sha512-GNoOaLRBM0gvH+ZRb2vKCIujzz4aclli64MBwDuYGU2EY53LwiP7MxOZGE46UGtotrSnmarPPZ69l2S/uxdaWA==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-arguments": "^4.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            }
+        },
+        "postcss-normalize-repeat-style": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.1.tgz",
+            "integrity": "sha512-fFHPGIjBUyUiswY2rd9rsFcC0t3oRta4wxE1h3lpwfQZwFeFjXFSiDtdJ7APCmHQOnUZnqYBADNRPKPwFAONgA==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-arguments": "^4.0.0",
+                "cssnano-util-get-match": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            }
+        },
+        "postcss-normalize-string": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.1.tgz",
+            "integrity": "sha512-IJoexFTkAvAq5UZVxWXAGE0yLoNN/012v7TQh5nDo6imZJl2Fwgbhy3J2qnIoaDBrtUP0H7JrXlX1jjn2YcvCQ==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            }
+        },
+        "postcss-normalize-timing-functions": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.1.tgz",
+            "integrity": "sha512-1nOtk7ze36+63ONWD8RCaRDYsnzorrj+Q6fxkQV+mlY5+471Qx9kspqv0O/qQNMeApg8KNrRf496zHwJ3tBZ7w==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-match": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            }
+        },
+        "postcss-normalize-unicode": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+            "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
             }
         },
         "postcss-normalize-url": {
-            "version": "3.0.8",
-            "resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
-            "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+            "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
             "dev": true,
             "requires": {
                 "is-absolute-url": "^2.0.0",
-                "normalize-url": "^1.4.0",
-                "postcss": "^5.0.14",
-                "postcss-value-parser": "^3.2.3"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
+                "normalize-url": "^3.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            }
+        },
+        "postcss-normalize-whitespace": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.1.tgz",
+            "integrity": "sha512-U8MBODMB2L+nStzOk6VvWWjZgi5kQNShCyjRhMT3s+W9Jw93yIjOnrEkKYD3Ul7ChWbEcjDWmXq0qOL9MIAnAw==",
+            "dev": true,
+            "requires": {
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
             }
         },
         "postcss-ordered-values": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
-            "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.1.tgz",
+            "integrity": "sha512-PeJiLgJWPzkVF8JuKSBcylaU+hDJ/TX3zqAMIjlghgn1JBi6QwQaDZoDIlqWRcCAI8SxKrt3FCPSRmOgKRB97Q==",
             "dev": true,
             "requires": {
-                "postcss": "^5.0.4",
-                "postcss-value-parser": "^3.0.1"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-reduce-idents": {
-            "version": "2.4.0",
-            "resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
-            "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.0.4",
-                "postcss-value-parser": "^3.0.2"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
+                "cssnano-util-get-arguments": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
             }
         },
         "postcss-reduce-initial": {
-            "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
-            "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.2.tgz",
+            "integrity": "sha512-epUiC39NonKUKG+P3eAOKKZtm5OtAtQJL7Ye0CBN1f+UQTHzqotudp+hki7zxXm7tT0ZAKDMBj1uihpPjP25ug==",
             "dev": true,
             "requires": {
-                "postcss": "^5.0.4"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
+                "browserslist": "^4.0.0",
+                "caniuse-api": "^3.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0"
             }
         },
         "postcss-reduce-transforms": {
-            "version": "1.0.4",
-            "resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
-            "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.1.tgz",
+            "integrity": "sha512-sZVr3QlGs0pjh6JAIe6DzWvBaqYw05V1t3d9Tp+VnFRT5j+rsqoWsysh/iSD7YNsULjq9IAylCznIwVd5oU/zA==",
             "dev": true,
             "requires": {
-                "has": "^1.0.1",
-                "postcss": "^5.0.8",
-                "postcss-value-parser": "^3.0.1"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
+                "cssnano-util-get-match": "^4.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
             }
         },
         "postcss-selector-parser": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-            "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+            "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
             "dev": true,
             "requires": {
-                "flatten": "^1.0.2",
+                "cssesc": "^2.0.0",
                 "indexes-of": "^1.0.1",
                 "uniq": "^1.0.1"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+                    "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+                    "dev": true
+                }
             }
         },
         "postcss-svgo": {
-            "version": "2.1.6",
-            "resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
-            "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.1.tgz",
+            "integrity": "sha512-YD5uIk5NDRySy0hcI+ZJHwqemv2WiqqzDgtvgMzO8EGSkK5aONyX8HMVFRFJSdO8wUWTuisUFn/d7yRRbBr5Qw==",
             "dev": true,
             "requires": {
-                "is-svg": "^2.0.0",
-                "postcss": "^5.0.14",
-                "postcss-value-parser": "^3.2.3",
-                "svgo": "^0.7.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
+                "is-svg": "^3.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0",
+                "svgo": "^1.0.0"
             }
         },
         "postcss-unique-selectors": {
-            "version": "2.0.2",
-            "resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
-            "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+            "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
             "dev": true,
             "requires": {
-                "alphanum-sort": "^1.0.1",
-                "postcss": "^5.0.4",
+                "alphanum-sort": "^1.0.0",
+                "postcss": "^7.0.0",
                 "uniqs": "^2.0.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
             }
         },
         "postcss-value-parser": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-            "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
-            "dev": true
-        },
-        "postcss-zindex": {
-            "version": "2.2.0",
-            "resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
-            "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-            "dev": true,
-            "requires": {
-                "has": "^1.0.1",
-                "postcss": "^5.0.4",
-                "uniqs": "^2.0.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.1.3",
-                        "js-base64": "^2.1.9",
-                        "source-map": "^0.5.6",
-                        "supports-color": "^3.2.3"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "prepend-http": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+            "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
             "dev": true
         },
         "preserve": {
@@ -8391,9 +8644,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
-            "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==",
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
+            "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
             "dev": true
         },
         "private": {
@@ -8457,9 +8710,9 @@
             }
         },
         "pump": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
             "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
@@ -8475,12 +8728,24 @@
                 "duplexify": "^3.6.0",
                 "inherits": "^2.0.3",
                 "pump": "^2.0.0"
+            },
+            "dependencies": {
+                "pump": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                    "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
             }
         },
         "punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
             "dev": true
         },
         "q": {
@@ -8494,16 +8759,6 @@
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
             "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
             "dev": true
-        },
-        "query-string": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-            "dev": true,
-            "requires": {
-                "object-assign": "^4.1.0",
-                "strict-uri-encode": "^1.0.0"
-            }
         },
         "querystring": {
             "version": "0.2.0",
@@ -8667,60 +8922,6 @@
                 "esprima": "~3.1.0",
                 "private": "~0.1.5",
                 "source-map": "~0.5.0"
-            },
-            "dependencies": {
-                "esprima": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-                    "dev": true
-                }
-            }
-        },
-        "redent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-            "dev": true,
-            "requires": {
-                "indent-string": "^2.1.0",
-                "strip-indent": "^1.0.1"
-            }
-        },
-        "reduce-css-calc": {
-            "version": "1.3.0",
-            "resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-            "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-            "dev": true,
-            "requires": {
-                "balanced-match": "^0.4.2",
-                "math-expression-evaluator": "^1.2.14",
-                "reduce-function-call": "^1.0.1"
-            },
-            "dependencies": {
-                "balanced-match": {
-                    "version": "0.4.2",
-                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                    "dev": true
-                }
-            }
-        },
-        "reduce-function-call": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
-            "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-            "dev": true,
-            "requires": {
-                "balanced-match": "^0.4.2"
-            },
-            "dependencies": {
-                "balanced-match": {
-                    "version": "0.4.2",
-                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                    "dev": true
-                }
             }
         },
         "regenerate": {
@@ -8729,20 +8930,27 @@
             "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
             "dev": true
         },
+        "regenerate-unicode-properties": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+            "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0"
+            }
+        },
         "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+            "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
             "dev": true
         },
         "regenerator-transform": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-            "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+            "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.18.0",
-                "babel-types": "^6.19.0",
                 "private": "^0.1.6"
             }
         },
@@ -8765,33 +8973,162 @@
                 "safe-regex": "^1.1.0"
             }
         },
-        "regex-parser": {
-            "version": "2.2.9",
-            "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.9.tgz",
-            "integrity": "sha512-VncXxOF6uFlYog5prG2j+e2UGJeam5MfNiJnB/qEgo4KTnMm2XrELCg4rNZ6IlaEUZnGlb8aB6lXowCRQtTkkA==",
-            "dev": true
-        },
-        "regexpu-core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-            "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+        "regexp-tree": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.1.tgz",
+            "integrity": "sha512-HwRjOquc9QOwKTgbxvZTcddS5mlNlwePMQ3NFL8broajMLD5CXDAqas8Y5yxJH5QtZp5iRor3YCILd5pz71Cgw==",
             "dev": true,
             "requires": {
-                "regenerate": "^1.2.1",
-                "regjsgen": "^0.2.0",
-                "regjsparser": "^0.1.4"
+                "cli-table3": "^0.5.0",
+                "colors": "^1.1.2",
+                "yargs": "^12.0.5"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+                    "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "regexpu-core": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
+            "integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^7.0.0",
+                "regjsgen": "^0.5.0",
+                "regjsparser": "^0.6.0",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.0.2"
             }
         },
         "regjsgen": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-            "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+            "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
             "dev": true
         },
         "regjsparser": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-            "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+            "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
             "dev": true,
             "requires": {
                 "jsesc": "~0.5.0"
@@ -8837,50 +9174,11 @@
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
-        "repeating": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-            "dev": true,
-            "requires": {
-                "is-finite": "^1.0.0"
-            }
-        },
-        "request": {
-            "version": "2.87.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-            "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-            "dev": true,
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
-            },
-            "dependencies": {
-                "qs": {
-                    "version": "6.5.2",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-                    "dev": true
-                }
-            }
+        "replace-ext": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+            "dev": true
         },
         "require-directory": {
             "version": "2.1.1",
@@ -8907,12 +9205,12 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "^1.0.6"
             }
         },
         "resolve-cwd": {
@@ -8922,6 +9220,16 @@
             "dev": true,
             "requires": {
                 "resolve-from": "^3.0.0"
+            }
+        },
+        "resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-from": {
@@ -8935,31 +9243,6 @@
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
             "dev": true
-        },
-        "resolve-url-loader": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-2.3.1.tgz",
-            "integrity": "sha512-tpt4A/tOT8jxRDa91RbBV4c22AGj+WllOxT8rYSYhT2XDdL33Nca9HudwVx4mvP9PLokz+wpCu44tWUGVMYYLA==",
-            "dev": true,
-            "requires": {
-                "adjust-sourcemap-loader": "^1.1.0",
-                "camelcase": "^4.1.0",
-                "convert-source-map": "^1.5.1",
-                "loader-utils": "^1.1.0",
-                "lodash.defaults": "^4.0.0",
-                "rework": "^1.0.1",
-                "rework-visit": "^1.0.0",
-                "source-map": "^0.5.7",
-                "urix": "^0.1.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-                    "dev": true
-                }
-            }
         },
         "resp-modifier": {
             "version": "6.0.2",
@@ -8988,46 +9271,25 @@
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
         },
-        "rework": {
+        "rgb-regex": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
-            "integrity": "sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=",
-            "dev": true,
-            "requires": {
-                "convert-source-map": "^0.3.3",
-                "css": "^2.0.0"
-            },
-            "dependencies": {
-                "convert-source-map": {
-                    "version": "0.3.5",
-                    "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
-                    "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
-                    "dev": true
-                }
-            }
-        },
-        "rework-visit": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz",
-            "integrity": "sha1-mUWygD8hni96ygCtuLyfZA+ELJo=",
+            "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+            "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
             "dev": true
         },
-        "right-align": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-            "dev": true,
-            "requires": {
-                "align-text": "^0.1.1"
-            }
+        "rgba-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+            "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
+            "dev": true
         },
         "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "^7.1.3"
             }
         },
         "ripemd160": {
@@ -9085,71 +9347,6 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
         },
-        "sass-graph": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-            "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-            "dev": true,
-            "requires": {
-                "glob": "^7.0.0",
-                "lodash": "^4.0.0",
-                "scss-tokenizer": "^0.2.3",
-                "yargs": "^7.0.0"
-            },
-            "dependencies": {
-                "yargs": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^5.0.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "sass-loader": {
-            "version": "6.0.7",
-            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.7.tgz",
-            "integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
-            "dev": true,
-            "requires": {
-                "clone-deep": "^2.0.1",
-                "loader-utils": "^1.0.1",
-                "lodash.tail": "^4.1.1",
-                "neo-async": "^2.5.0",
-                "pify": "^3.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                }
-            }
-        },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -9157,33 +9354,13 @@
             "dev": true
         },
         "schema-utils": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-            "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+            "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
             "dev": true,
             "requires": {
-                "ajv": "^5.0.0"
-            }
-        },
-        "scss-tokenizer": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-            "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-            "dev": true,
-            "requires": {
-                "js-base64": "^2.1.8",
-                "source-map": "^0.4.2"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.4.4",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                    "dev": true,
-                    "requires": {
-                        "amdefine": ">=0.0.4"
-                    }
-                }
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0"
             }
         },
         "select-hose": {
@@ -9255,9 +9432,9 @@
             }
         },
         "serialize-javascript": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-            "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
+            "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==",
             "dev": true
         },
         "serve-index": {
@@ -9347,31 +9524,12 @@
         },
         "sha.js": {
             "version": "2.4.11",
-            "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "shallow-clone": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
-            "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
-            "dev": true,
-            "requires": {
-                "is-extendable": "^0.1.1",
-                "kind-of": "^5.0.0",
-                "mixin-object": "^2.0.1"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
-                }
             }
         },
         "shebang-command": {
@@ -9400,6 +9558,23 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
+        },
+        "simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.3.1"
+            },
+            "dependencies": {
+                "is-arrayish": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+                    "dev": true
+                }
+            }
         },
         "slash": {
             "version": "1.0.0",
@@ -9535,6 +9710,71 @@
                 "socket.io-adapter": "~1.1.0",
                 "socket.io-client": "2.1.1",
                 "socket.io-parser": "~3.2.0"
+            },
+            "dependencies": {
+                "engine.io-client": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+                    "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+                    "dev": true,
+                    "requires": {
+                        "component-emitter": "1.2.1",
+                        "component-inherit": "0.0.3",
+                        "debug": "~3.1.0",
+                        "engine.io-parser": "~2.1.1",
+                        "has-cors": "1.1.0",
+                        "indexof": "0.0.1",
+                        "parseqs": "0.0.5",
+                        "parseuri": "0.0.5",
+                        "ws": "~3.3.1",
+                        "xmlhttprequest-ssl": "~1.5.4",
+                        "yeast": "0.1.2"
+                    }
+                },
+                "socket.io-client": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+                    "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+                    "dev": true,
+                    "requires": {
+                        "backo2": "1.0.2",
+                        "base64-arraybuffer": "0.1.5",
+                        "component-bind": "1.0.0",
+                        "component-emitter": "1.2.1",
+                        "debug": "~3.1.0",
+                        "engine.io-client": "~3.2.0",
+                        "has-binary2": "~1.0.2",
+                        "has-cors": "1.1.0",
+                        "indexof": "0.0.1",
+                        "object-component": "0.0.3",
+                        "parseqs": "0.0.5",
+                        "parseuri": "0.0.5",
+                        "socket.io-parser": "~3.2.0",
+                        "to-array": "0.1.4"
+                    }
+                },
+                "socket.io-parser": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+                    "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+                    "dev": true,
+                    "requires": {
+                        "component-emitter": "1.2.1",
+                        "debug": "~3.1.0",
+                        "isarray": "2.0.1"
+                    }
+                },
+                "ws": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
+                    }
+                }
             }
         },
         "socket.io-adapter": {
@@ -9544,9 +9784,9 @@
             "dev": true
         },
         "socket.io-client": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-            "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+            "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
             "dev": true,
             "requires": {
                 "backo2": "1.0.2",
@@ -9554,21 +9794,21 @@
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
                 "debug": "~3.1.0",
-                "engine.io-client": "~3.2.0",
+                "engine.io-client": "~3.3.1",
                 "has-binary2": "~1.0.2",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "~3.2.0",
+                "socket.io-parser": "~3.3.0",
                 "to-array": "0.1.4"
             }
         },
         "socket.io-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-            "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+            "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
@@ -9587,26 +9827,26 @@
             }
         },
         "sockjs-client": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
-            "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+            "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.6",
-                "eventsource": "0.1.6",
-                "faye-websocket": "~0.11.0",
-                "inherits": "^2.0.1",
+                "debug": "^3.2.5",
+                "eventsource": "^1.0.7",
+                "faye-websocket": "~0.11.1",
+                "inherits": "^2.0.3",
                 "json3": "^3.3.2",
-                "url-parse": "^1.1.8"
+                "url-parse": "^1.4.3"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
                 },
                 "faye-websocket": {
@@ -9617,16 +9857,13 @@
                     "requires": {
                         "websocket-driver": ">=0.5.1"
                     }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
                 }
-            }
-        },
-        "sort-keys": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-            "dev": true,
-            "requires": {
-                "is-plain-obj": "^1.0.0"
             }
         },
         "source-list-map": {
@@ -9655,12 +9892,21 @@
             }
         },
         "source-map-support": {
-            "version": "0.4.18",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+            "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
             "dev": true,
             "requires": {
-                "source-map": "^0.5.6"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
             }
         },
         "source-map-url": {
@@ -9702,52 +9948,73 @@
             "dev": true
         },
         "spdy": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-            "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
+            "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.8",
-                "handle-thing": "^1.2.5",
+                "debug": "^4.1.0",
+                "handle-thing": "^2.0.0",
                 "http-deceiver": "^1.2.7",
-                "safe-buffer": "^5.0.1",
                 "select-hose": "^2.0.0",
-                "spdy-transport": "^2.0.18"
+                "spdy-transport": "^3.0.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
                 }
             }
         },
         "spdy-transport": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
-            "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.8",
-                "detect-node": "^2.0.3",
+                "debug": "^4.1.0",
+                "detect-node": "^2.0.4",
                 "hpack.js": "^2.1.6",
-                "obuf": "^1.1.1",
-                "readable-stream": "^2.2.9",
-                "safe-buffer": "^5.0.1",
-                "wbuf": "^1.7.2"
+                "obuf": "^1.1.2",
+                "readable-stream": "^3.0.6",
+                "wbuf": "^1.7.3"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+                    "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
                     }
                 }
             }
@@ -9767,31 +10034,20 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
-        "sshpk": {
-            "version": "1.14.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+        "ssri": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+            "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
             "dev": true,
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "figgy-pudding": "^3.5.1"
             }
         },
-        "ssri": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-            "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.1.1"
-            }
+        "stable": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+            "dev": true
         },
         "stackframe": {
             "version": "1.0.4",
@@ -9826,19 +10082,10 @@
             "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
             "dev": true
         },
-        "stdout-stream": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
-            "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
-            "dev": true,
-            "requires": {
-                "readable-stream": "^2.0.1"
-            }
-        },
         "stream-browserify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-            "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+            "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
             "dev": true,
             "requires": {
                 "inherits": "~2.0.1",
@@ -9884,12 +10131,6 @@
                 "limiter": "^1.0.5"
             }
         },
-        "strict-uri-encode": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-            "dev": true
-        },
         "string-width": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -9934,23 +10175,51 @@
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
-        "strip-indent": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+        "style-loader": {
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
+            "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
             "dev": true,
             "requires": {
-                "get-stdin": "^4.0.1"
+                "loader-utils": "^1.1.0",
+                "schema-utils": "^1.0.0"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                }
             }
         },
-        "style-loader": {
-            "version": "0.18.2",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.18.2.tgz",
-            "integrity": "sha512-WPpJPZGUxWYHWIUMNNOYqql7zh85zGmr84FdTVWq52WTIkqlW9xSxD3QYWi/T31cqn9UNSsietVEgGn2aaSCzw==",
+        "stylehacks": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.1.tgz",
+            "integrity": "sha512-TK5zEPeD9NyC1uPIdjikzsgWxdQQN/ry1X3d1iOz1UkYDCmcr928gWD1KHgyC27F50UnE0xCTrBOO1l6KR8M4w==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.0.2",
-                "schema-utils": "^0.3.0"
+                "browserslist": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-selector-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "^4.1.1",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
+                    }
+                }
             }
         },
         "supports-color": {
@@ -9960,18 +10229,33 @@
             "dev": true
         },
         "svgo": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
-            "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.1.1.tgz",
+            "integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
             "dev": true,
             "requires": {
-                "coa": "~1.0.1",
+                "coa": "~2.0.1",
                 "colors": "~1.1.2",
-                "csso": "~2.3.1",
-                "js-yaml": "~3.7.0",
+                "css-select": "^2.0.0",
+                "css-select-base-adapter": "~0.1.0",
+                "css-tree": "1.0.0-alpha.28",
+                "css-url-regex": "^1.1.0",
+                "csso": "^3.5.0",
+                "js-yaml": "^3.12.0",
                 "mkdirp": "~0.5.1",
-                "sax": "~1.2.1",
-                "whet.extend": "~0.9.9"
+                "object.values": "^1.0.4",
+                "sax": "~1.2.4",
+                "stable": "~0.1.6",
+                "unquote": "~1.1.1",
+                "util.promisify": "~1.0.0"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+                    "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+                    "dev": true
+                }
             }
         },
         "symbol-observable": {
@@ -9981,20 +10265,69 @@
             "dev": true
         },
         "tapable": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-            "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
+            "integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==",
             "dev": true
         },
-        "tar": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+        "terser": {
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-3.16.1.tgz",
+            "integrity": "sha512-JDJjgleBROeek2iBcSNzOHLKsB/MdDf+E/BOAJ0Tk9r7p9/fVobfv7LMJ/g/k3v9SXdmjZnIlFd5nfn/Rt0Xow==",
             "dev": true,
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "commander": "~2.17.1",
+                "source-map": "~0.6.1",
+                "source-map-support": "~0.5.9"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.17.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+                    "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "terser-webpack-plugin": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.2.tgz",
+            "integrity": "sha512-1DMkTk286BzmfylAvLXwpJrI7dWa5BnFmscV/2dCr8+c56egFcbaeFAl7+sujAjdmpLam21XRdhA4oifLyiWWg==",
+            "dev": true,
+            "requires": {
+                "cacache": "^11.0.2",
+                "find-cache-dir": "^2.0.0",
+                "schema-utils": "^1.0.0",
+                "serialize-javascript": "^1.4.0",
+                "source-map": "^0.6.1",
+                "terser": "^3.16.1",
+                "webpack-sources": "^1.1.0",
+                "worker-farm": "^1.5.2"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
             }
         },
         "tfunk": {
@@ -10009,30 +10342,24 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
         "through2": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.1.5",
+                "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
             }
         },
         "thunky": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
-            "integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E=",
-            "dev": true
-        },
-        "time-stamp": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.1.0.tgz",
-            "integrity": "sha512-lJbq6KsFhZJtN3fPUVje1tq/hHsJOKUUcUj/MGCiQR6qWBDcyi5kxL9J7/RnaEChCn0+L/DUN2WvemDrkk4i3Q==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
+            "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==",
             "dev": true
         },
         "timers-browserify": {
@@ -10043,6 +10370,12 @@
             "requires": {
                 "setimmediate": "^1.0.4"
             }
+        },
+        "timsort": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+            "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+            "dev": true
         },
         "to-array": {
             "version": "0.1.4",
@@ -10057,9 +10390,9 @@
             "dev": true
         },
         "to-fast-properties": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
             "dev": true
         },
         "to-object-path": {
@@ -10104,25 +10437,10 @@
                 "repeat-string": "^1.6.1"
             }
         },
-        "tough-cookie": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-            "dev": true,
-            "requires": {
-                "punycode": "^1.4.1"
-            }
-        },
         "traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
             "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
-        },
-        "trim-newlines": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-            "dev": true
         },
         "trim-right": {
             "version": "1.0.1",
@@ -10130,36 +10448,17 @@
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
-        "true-case-path": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
-            "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.2"
-            }
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+            "dev": true
         },
         "tty-browserify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
             "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
             "dev": true
-        },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true,
-            "optional": true
         },
         "type-is": {
             "version": "1.6.16",
@@ -10184,131 +10483,26 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "2.8.29",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+            "version": "3.4.9",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+            "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
             "dev": true,
             "requires": {
-                "source-map": "~0.5.1",
-                "uglify-to-browserify": "~1.0.0",
-                "yargs": "~3.10.0"
+                "commander": "~2.17.1",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
-                "camelcase": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                    "dev": true
-                },
-                "cliui": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                    "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                    "dev": true,
-                    "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
-                        "wordwrap": "0.0.2"
-                    }
-                },
-                "window-size": {
-                    "version": "0.1.0",
-                    "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                    "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "3.10.0",
-                    "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^1.0.2",
-                        "cliui": "^2.1.0",
-                        "decamelize": "^1.0.0",
-                        "window-size": "0.1.0"
-                    }
-                }
-            }
-        },
-        "uglify-to-browserify": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-            "dev": true,
-            "optional": true
-        },
-        "uglifyjs-webpack-plugin": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-            "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-            "dev": true,
-            "requires": {
-                "cacache": "^10.0.4",
-                "find-cache-dir": "^1.0.0",
-                "schema-utils": "^0.4.5",
-                "serialize-javascript": "^1.4.0",
-                "source-map": "^0.6.1",
-                "uglify-es": "^3.3.4",
-                "webpack-sources": "^1.1.0",
-                "worker-farm": "^1.5.2"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "6.5.4",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-                    "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
                 "commander": {
-                    "version": "2.13.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-                    "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+                    "version": "2.17.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+                    "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
                     "dev": true
-                },
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-                    "dev": true
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-                    "dev": true
-                },
-                "schema-utils": {
-                    "version": "0.4.7",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-                    "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-keywords": "^3.1.0"
-                    }
                 },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
-                },
-                "uglify-es": {
-                    "version": "3.3.9",
-                    "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-                    "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-                    "dev": true,
-                    "requires": {
-                        "commander": "~2.13.0",
-                        "source-map": "~0.6.1"
-                    }
                 }
             }
         },
@@ -10316,6 +10510,34 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
             "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+            "dev": true
+        },
+        "unicode-canonical-property-names-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+            "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+            "dev": true,
+            "requires": {
+                "unicode-canonical-property-names-ecmascript": "^1.0.4",
+                "unicode-property-aliases-ecmascript": "^1.0.4"
+            }
+        },
+        "unicode-match-property-value-ecmascript": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+            "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+            "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
             "dev": true
         },
         "union-value": {
@@ -10395,6 +10617,12 @@
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
             "dev": true
         },
+        "unquote": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+            "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+            "dev": true
+        },
         "unset-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -10460,14 +10688,6 @@
             "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-                    "dev": true
-                }
             }
         },
         "urix": {
@@ -10495,9 +10715,9 @@
             }
         },
         "url-parse": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-            "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+            "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
             "dev": true,
             "requires": {
                 "querystringify": "^2.0.0",
@@ -10533,6 +10753,16 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
+        "util.promisify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
+        },
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -10543,6 +10773,12 @@
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
             "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "dev": true
+        },
+        "v8-compile-cache": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
+            "integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
             "dev": true
         },
         "validate-npm-package-license": {
@@ -10567,17 +10803,6 @@
             "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
             "dev": true
         },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
         "vm-browserify": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
@@ -10588,9 +10813,9 @@
             }
         },
         "vue": {
-            "version": "2.5.17",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.17.tgz",
-            "integrity": "sha512-mFbcWoDIJi0w0Za4emyLiW72Jae0yjANHbCVquMKijcavBGypqlF7zHRgMa5k4sesdv7hv2rB4JPdZfR+TPfhQ=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.2.tgz",
+            "integrity": "sha512-NZAb0H+t3/99g2nygURcEJ+ncvzNLPiEiFI5MGhc1Cjsw5uYprF+Ol7SOd1RXPcmVVzK7jUBl0th2tNgt+VQDg=="
         },
         "vue-hot-reload-api": {
             "version": "2.3.1",
@@ -10599,97 +10824,32 @@
             "dev": true
         },
         "vue-loader": {
-            "version": "13.7.3",
-            "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-13.7.3.tgz",
-            "integrity": "sha512-ACCwbfeC6HjY2pnDii+Zer+MZ6sdOtwvLmDXRK/BoD3WNR551V22R6KEagwHoTRJ0ZlIhpCBkptpCU6+Ri/05w==",
+            "version": "15.6.2",
+            "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.6.2.tgz",
+            "integrity": "sha512-T6fONodj861M3PqZ1jlbUFjeezbUnPRY2bd+3eZuDvYADgkN3VFU2H5feqySNg9XBt8rcbyBGmFWTZtrOX+v5w==",
             "dev": true,
             "requires": {
-                "consolidate": "^0.14.0",
+                "@vue/component-compiler-utils": "^2.5.1",
                 "hash-sum": "^1.0.2",
                 "loader-utils": "^1.1.0",
-                "lru-cache": "^4.1.1",
-                "postcss": "^6.0.8",
-                "postcss-load-config": "^1.1.0",
-                "postcss-selector-parser": "^2.0.0",
-                "prettier": "^1.7.0",
-                "resolve": "^1.4.0",
-                "source-map": "^0.6.1",
-                "vue-hot-reload-api": "^2.2.0",
-                "vue-style-loader": "^3.0.0",
-                "vue-template-es2015-compiler": "^1.6.0"
-            },
-            "dependencies": {
-                "cosmiconfig": {
-                    "version": "2.2.2",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-                    "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-                    "dev": true,
-                    "requires": {
-                        "is-directory": "^0.3.1",
-                        "js-yaml": "^3.4.3",
-                        "minimist": "^1.2.0",
-                        "object-assign": "^4.1.0",
-                        "os-homedir": "^1.0.1",
-                        "parse-json": "^2.2.0",
-                        "require-from-string": "^1.1.0"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "postcss-load-config": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
-                    "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
-                    "dev": true,
-                    "requires": {
-                        "cosmiconfig": "^2.1.0",
-                        "object-assign": "^4.1.0",
-                        "postcss-load-options": "^1.2.0",
-                        "postcss-load-plugins": "^2.3.0"
-                    }
-                },
-                "require-from-string": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-                    "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
+                "vue-hot-reload-api": "^2.3.0",
+                "vue-style-loader": "^4.1.0"
             }
         },
         "vue-style-loader": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-3.1.2.tgz",
-            "integrity": "sha512-ICtVdK/p+qXWpdSs2alWtsXt9YnDoYjQe0w5616j9+/EhjoxZkbun34uWgsMFnC1MhrMMwaWiImz3K2jK1Yp2Q==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",
+            "integrity": "sha512-0ip8ge6Gzz/Bk0iHovU9XAUQaFt/G2B61bnWa2tCcqqdgfHs1lF9xXorFbE55Gmy92okFT+8bfmySuUOu13vxQ==",
             "dev": true,
             "requires": {
                 "hash-sum": "^1.0.2",
                 "loader-utils": "^1.0.2"
             }
         },
-        "vue-template-compiler": {
-            "version": "2.5.17",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.17.tgz",
-            "integrity": "sha512-63uI4syCwtGR5IJvZM0LN5tVsahrelomHtCxvRkZPJ/Tf3ADm1U1wG6KWycK3qCfqR+ygM5vewUvmJ0REAYksg==",
-            "dev": true,
-            "requires": {
-                "de-indent": "^1.0.2",
-                "he": "^1.1.0"
-            }
-        },
         "vue-template-es2015-compiler": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
-            "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.8.2.tgz",
+            "integrity": "sha512-cliV19VHLJqFUYbz/XeWXe5CO6guzwd0yrrqqp0bmjlMP3ZZULY7fu8RTC4+3lmHwo6ESVDHFDsvjB15hcR5IA==",
             "dev": true
         },
         "watchpack": {
@@ -10713,87 +10873,159 @@
             }
         },
         "webpack": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
-            "integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
+            "version": "4.29.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.2.tgz",
+            "integrity": "sha512-CIImg29B6IcIsQwxZJ6DtWXR024wX6vHfU8fB1UDxtSiEY1gwoqE1uSAi459vBOJuIYshu4BwMI7gxjVUqXPUg==",
             "dev": true,
             "requires": {
-                "acorn": "^5.0.0",
-                "acorn-dynamic-import": "^2.0.0",
+                "@webassemblyjs/ast": "1.7.11",
+                "@webassemblyjs/helper-module-context": "1.7.11",
+                "@webassemblyjs/wasm-edit": "1.7.11",
+                "@webassemblyjs/wasm-parser": "1.7.11",
+                "acorn": "^6.0.5",
+                "acorn-dynamic-import": "^4.0.0",
                 "ajv": "^6.1.0",
                 "ajv-keywords": "^3.1.0",
-                "async": "^2.1.2",
-                "enhanced-resolve": "^3.4.0",
-                "escope": "^3.6.0",
-                "interpret": "^1.0.0",
-                "json-loader": "^0.5.4",
-                "json5": "^0.5.1",
+                "chrome-trace-event": "^1.0.0",
+                "enhanced-resolve": "^4.1.0",
+                "eslint-scope": "^4.0.0",
+                "json-parse-better-errors": "^1.0.2",
                 "loader-runner": "^2.3.0",
                 "loader-utils": "^1.1.0",
                 "memory-fs": "~0.4.1",
+                "micromatch": "^3.1.8",
                 "mkdirp": "~0.5.0",
+                "neo-async": "^2.5.0",
                 "node-libs-browser": "^2.0.0",
-                "source-map": "^0.5.3",
-                "supports-color": "^4.2.1",
-                "tapable": "^0.2.7",
-                "uglifyjs-webpack-plugin": "^0.4.6",
-                "watchpack": "^1.4.0",
-                "webpack-sources": "^1.0.1",
-                "yargs": "^8.0.2"
+                "schema-utils": "^1.0.0",
+                "tapable": "^1.1.0",
+                "terser-webpack-plugin": "^1.1.0",
+                "watchpack": "^1.5.0",
+                "webpack-sources": "^1.3.0"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "6.5.4",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-                    "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                }
+            }
+        },
+        "webpack-cli": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.2.3.tgz",
+            "integrity": "sha512-Ik3SjV6uJtWIAN5jp5ZuBMWEAaP5E4V78XJ2nI+paFPh8v4HPSwo/myN0r29Xc/6ZKnd2IdrAlpSgNOu2CDQ6Q==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "enhanced-resolve": "^4.1.0",
+                "findup-sync": "^2.0.0",
+                "global-modules": "^1.0.0",
+                "import-local": "^2.0.0",
+                "interpret": "^1.1.0",
+                "loader-utils": "^1.1.0",
+                "supports-color": "^5.5.0",
+                "v8-compile-cache": "^2.0.2",
+                "yargs": "^12.0.4"
+            },
+            "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
-                "async": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-                    "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "lodash": "^4.17.10"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+                    "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
                     "dev": true
                 },
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-                    "dev": true
-                },
-                "find-up": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
-                "has-flag": {
+                "cliui": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
@@ -10802,63 +11034,24 @@
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-                    "dev": true
-                },
-                "load-json-file": {
+                "lcid": {
                     "version": "2.0.0",
-                    "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-                    "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "strip-bom": "^3.0.0"
+                        "invert-kv": "^2.0.0"
                     }
                 },
                 "os-locale": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-                    "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
-                    }
-                },
-                "path-type": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-                    "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-                    "dev": true,
-                    "requires": {
-                        "pify": "^2.0.0"
-                    }
-                },
-                "read-pkg": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-                    "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-                    "dev": true,
-                    "requires": {
-                        "load-json-file": "^2.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^2.0.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-                    "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^2.0.0",
-                        "read-pkg": "^2.0.0"
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
                     }
                 },
                 "string-width": {
@@ -10880,132 +11073,6 @@
                         "ansi-regex": "^3.0.0"
                     }
                 },
-                "strip-bom": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^2.0.0"
-                    }
-                },
-                "uglifyjs-webpack-plugin": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-                    "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-                    "dev": true,
-                    "requires": {
-                        "source-map": "^0.5.6",
-                        "uglify-js": "^2.8.29",
-                        "webpack-sources": "^1.0.1"
-                    }
-                },
-                "which-module": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "8.0.2",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-                    "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^4.1.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
-                        "read-pkg-up": "^2.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^7.0.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-                    "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^4.1.0"
-                    }
-                }
-            }
-        },
-        "webpack-chunk-hash": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/webpack-chunk-hash/-/webpack-chunk-hash-0.4.0.tgz",
-            "integrity": "sha1-a0DDBw+8n/DP4P54HHF0r2x8FqQ=",
-            "dev": true
-        },
-        "webpack-dev-middleware": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-            "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
-            "dev": true,
-            "requires": {
-                "memory-fs": "~0.4.1",
-                "mime": "^1.5.0",
-                "path-is-absolute": "^1.0.0",
-                "range-parser": "^1.0.3",
-                "time-stamp": "^2.0.0"
-            },
-            "dependencies": {
-                "mime": {
-                    "version": "1.6.0",
-                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-                    "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-                    "dev": true
-                }
-            }
-        },
-        "webpack-dev-server": {
-            "version": "2.11.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.3.tgz",
-            "integrity": "sha512-Qz22YEFhWx+M2vvJ+rQppRv39JA0h5NNbOOdODApdX6iZ52Diz7vTPXjF7kJlfn+Uc24Qr48I3SZ9yncQwRycg==",
-            "dev": true,
-            "requires": {
-                "ansi-html": "0.0.7",
-                "array-includes": "^3.0.3",
-                "bonjour": "^3.5.0",
-                "chokidar": "^2.0.0",
-                "compression": "^1.5.2",
-                "connect-history-api-fallback": "^1.3.0",
-                "debug": "^3.1.0",
-                "del": "^3.0.0",
-                "express": "^4.16.2",
-                "html-entities": "^1.2.0",
-                "http-proxy-middleware": "~0.17.4",
-                "import-local": "^1.0.0",
-                "internal-ip": "1.2.0",
-                "ip": "^1.1.5",
-                "killable": "^1.0.0",
-                "loglevel": "^1.4.1",
-                "opn": "^5.1.0",
-                "portfinder": "^1.0.9",
-                "selfsigned": "^1.9.1",
-                "serve-index": "^1.7.2",
-                "sockjs": "0.3.19",
-                "sockjs-client": "1.1.5",
-                "spdy": "^3.4.1",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^5.1.0",
-                "webpack-dev-middleware": "1.12.2",
-                "yargs": "6.6.0"
-            },
-            "dependencies": {
                 "supports-color": {
                     "version": "5.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -11015,33 +11082,284 @@
                         "has-flag": "^3.0.0"
                     }
                 },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
                 "yargs": {
-                    "version": "6.6.0",
-                    "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-                    "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+                    "version": "12.0.5",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
                         "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
+                        "os-locale": "^3.0.0",
                         "require-directory": "^2.1.1",
                         "require-main-filename": "^1.0.1",
                         "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^4.2.0"
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
                     }
                 }
             }
         },
+        "webpack-dev-middleware": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
+            "integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
+            "dev": true,
+            "requires": {
+                "memory-fs": "~0.4.1",
+                "mime": "^2.3.1",
+                "range-parser": "^1.0.3",
+                "webpack-log": "^2.0.0"
+            },
+            "dependencies": {
+                "mime": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+                    "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+                    "dev": true
+                }
+            }
+        },
+        "webpack-dev-server": {
+            "version": "3.1.14",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
+            "integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
+            "dev": true,
+            "requires": {
+                "ansi-html": "0.0.7",
+                "bonjour": "^3.5.0",
+                "chokidar": "^2.0.0",
+                "compression": "^1.5.2",
+                "connect-history-api-fallback": "^1.3.0",
+                "debug": "^3.1.0",
+                "del": "^3.0.0",
+                "express": "^4.16.2",
+                "html-entities": "^1.2.0",
+                "http-proxy-middleware": "~0.18.0",
+                "import-local": "^2.0.0",
+                "internal-ip": "^3.0.1",
+                "ip": "^1.1.5",
+                "killable": "^1.0.0",
+                "loglevel": "^1.4.1",
+                "opn": "^5.1.0",
+                "portfinder": "^1.0.9",
+                "schema-utils": "^1.0.0",
+                "selfsigned": "^1.9.1",
+                "semver": "^5.6.0",
+                "serve-index": "^1.7.2",
+                "sockjs": "0.3.19",
+                "sockjs-client": "1.3.0",
+                "spdy": "^4.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^5.1.0",
+                "url": "^0.11.0",
+                "webpack-dev-middleware": "3.4.0",
+                "webpack-log": "^2.0.0",
+                "yargs": "12.0.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "decamelize": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+                    "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+                    "dev": true,
+                    "requires": {
+                        "xregexp": "4.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                },
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "12.0.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+                    "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^2.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^10.1.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+                    "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "webpack-log": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+            "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^3.0.0",
+                "uuid": "^3.3.2"
+            }
+        },
         "webpack-merge": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.4.tgz",
-            "integrity": "sha512-TmSe1HZKeOPey3oy1Ov2iS3guIZjWvMT2BBJDzzT5jScHTjVC3mpjJofgueEzaEd6ibhxRDD6MIblDr8tzh8iQ==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
+            "integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
             "dev": true,
             "requires": {
                 "lodash": "^4.17.5"
@@ -11156,12 +11474,6 @@
             "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
             "dev": true
         },
-        "whet.extend": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-            "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
-            "dev": true
-        },
         "which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -11177,25 +11489,10 @@
             "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
             "dev": true
         },
-        "wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "dev": true,
-            "requires": {
-                "string-width": "^1.0.2 || 2"
-            }
-        },
         "window-size": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
             "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-            "dev": true
-        },
-        "wordwrap": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
             "dev": true
         },
         "worker-farm": {
@@ -11224,20 +11521,24 @@
             "dev": true
         },
         "ws": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-            "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
+            "integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
             "dev": true,
             "requires": {
-                "async-limiter": "~1.0.0",
-                "safe-buffer": "~5.1.0",
-                "ultron": "~1.1.0"
+                "async-limiter": "~1.0.0"
             }
         },
         "xmlhttprequest-ssl": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
             "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+            "dev": true
+        },
+        "xregexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+            "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
             "dev": true
         },
         "xtend": {

--- a/package.json
+++ b/package.json
@@ -8,20 +8,23 @@
         "watch": "npm run local -- --watch"
     },
     "devDependencies": {
-        "browser-sync": "^2.23.6",
+        "browser-sync": "^2.26.3",
         "browser-sync-webpack-plugin": "^2.0.1",
-        "bulma": "^0.7.1",
+        "bulma": "^0.7.2",
         "cross-env": "^3.2.3",
         "hasbin": "^1.2.3",
-        "laravel-mix": "^2.0.0",
+        "laravel-mix": "^4.0.0",
         "node-cmd": "^3.0.0",
         "on-build-webpack": "^0.1.0",
+        "sass": "^1.17.0",
+        "sass-loader": "7.*",
+        "vue-template-compiler": "^2.6.2",
         "webpack-watch": "^0.2.0",
         "yargs": "^4.6.0"
     },
     "dependencies": {
         "lodash": "^4.17.11",
         "remove": "^0.1.5",
-        "vue": "^2.5.17"
+        "vue": "^2.6.2"
     }
 }


### PR DESCRIPTION
Regarding the vulnerability on the package `webpack-dev-server` (version below than 3.11) we needed to update the major version of `laravel-mix` from `ˆ2.0.0` to `ˆ4.0.0`

We also added the dev dependency of `malukenho/mcbumpface` to make sure that the `composer.json` will be always with the version of the packages that we have on `composer.lock`