### PR TITLE
Fixes notice: undefined variable on breadcrumbs partial

### DIFF
--- a/source/_partials/layout/breadcrumbs.blade.php
+++ b/source/_partials/layout/breadcrumbs.blade.php
@@ -2,7 +2,7 @@
     <ul>
         <li><a href="/">PHPSP {{ $page->type }}</a></li>
 
-        @if ($isPost)
+        @if ($isPost ?? false)
             <li><a href="/artigos">Artigos</a></li>
         @endif
 


### PR DESCRIPTION
<img width="1221" alt="Screenshot 2019-05-01 at 00 36 51" src="https://user-images.githubusercontent.com/3905582/56997783-3e470e80-6ba9-11e9-8ba7-3159783b71d4.png">

Este PR corrige o notice de `undefined variable` na partial breadcrumbs.