### PR TITLE
Fixing vue-template-compiler and vue versions to 2.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2061,7 +2061,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -2082,12 +2083,14 @@
                         "balanced-match": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -2102,17 +2105,20 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -2229,7 +2235,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -2241,6 +2248,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -2255,6 +2263,7 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
@@ -2262,12 +2271,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -2286,6 +2297,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -2366,7 +2378,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -2378,6 +2391,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -2463,7 +2477,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -2499,6 +2514,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -2518,6 +2534,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -2561,12 +2578,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },
@@ -2696,6 +2715,29 @@
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1",
                 "wrap-ansi": "^2.0.0"
+            }
+        },
+        "clone-deep": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
+            "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.0",
+                "shallow-clone": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
             }
         },
         "coa": {
@@ -3397,6 +3439,12 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
             "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "de-indent": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+            "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
             "dev": true
         },
         "debug": {
@@ -4758,7 +4806,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -4779,12 +4828,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -4799,17 +4850,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -4926,7 +4980,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -4938,6 +4993,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -4952,6 +5008,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -4959,12 +5016,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -4983,6 +5042,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -5063,7 +5123,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -5075,6 +5136,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -5160,7 +5222,8 @@
                 "safe-buffer": {
                     "version": "5.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -5196,6 +5259,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -5215,6 +5279,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -5258,12 +5323,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -6788,6 +6855,12 @@
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
             "dev": true
         },
+        "lodash.tail": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
+            "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
+            "dev": true
+        },
         "lodash.uniq": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -7159,6 +7232,24 @@
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
+                }
+            }
+        },
+        "mixin-object": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+            "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+            "dev": true,
+            "requires": {
+                "for-in": "^0.1.3",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-in": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+                    "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+                    "dev": true
                 }
             }
         },
@@ -9347,6 +9438,37 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
         },
+        "sass": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.19.0.tgz",
+            "integrity": "sha512-8kzKCgxCzh8/zEn3AuRwzLWVSSFj8omkiGwqdJdeOufjM+I88dXxu9LYJ/Gw4rRTHXesN0r1AixBuqM6yLQUJw==",
+            "dev": true,
+            "requires": {
+                "chokidar": "^2.0.0"
+            }
+        },
+        "sass-loader": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.1.0.tgz",
+            "integrity": "sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==",
+            "dev": true,
+            "requires": {
+                "clone-deep": "^2.0.1",
+                "loader-utils": "^1.0.1",
+                "lodash.tail": "^4.1.1",
+                "neo-async": "^2.5.0",
+                "pify": "^3.0.0",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
+            }
+        },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -9530,6 +9652,25 @@
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
+            }
+        },
+        "shallow-clone": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
+            "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
+            "dev": true,
+            "requires": {
+                "is-extendable": "^0.1.1",
+                "kind-of": "^5.0.0",
+                "mixin-object": "^2.0.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
             }
         },
         "shebang-command": {
@@ -10844,6 +10985,16 @@
             "requires": {
                 "hash-sum": "^1.0.2",
                 "loader-utils": "^1.0.2"
+            }
+        },
+        "vue-template-compiler": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.2.tgz",
+            "integrity": "sha512-2dBKNCtBPdx1TFef7T4zwF8IjOx2xbMNryCtFzneP+XIonJwOtnkq4s1mhKv8W79gXcGINQWtuaxituGAcuSnA==",
+            "dev": true,
+            "requires": {
+                "de-indent": "^1.0.2",
+                "he": "^1.1.0"
             }
         },
         "vue-template-es2015-compiler": {

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
         "on-build-webpack": "^0.1.0",
         "sass": "^1.17.0",
         "sass-loader": "7.*",
-        "vue-template-compiler": "^2.6.2",
+        "vue-template-compiler": "2.6.2",
         "webpack-watch": "^0.2.0",
         "yargs": "^4.6.0"
     },
     "dependencies": {
         "lodash": "^4.17.11",
         "remove": "^0.1.5",
-        "vue": "^2.6.2"
+        "vue": "2.6.2"
     }
 }


### PR DESCRIPTION
Este pull request fixa os pacotes `vue-template-compiler` e `vue` na versão `2.6.2`, corrigindo os erros de build em dev e em prod. (inclusive neste pull request, visto que todos os outros falham por este motivo).

A implementação anterior permite o update de patches e, no momento atual, as versões seriam `2.6.10` e `2.6.2` para `vue-template-compiler` e `vue` respectivamente. Causando um erro de compilação por mismatch de versão em tempo de build.

<img width="954" alt="Screenshot 2019-05-01 at 00 56 48" src="https://user-images.githubusercontent.com/3905582/56998852-1c4f8b00-6bad-11e9-90ae-23ab73204ae4.png">
<img width="953" alt="Screenshot 2019-05-01 at 00 58 56" src="https://user-images.githubusercontent.com/3905582/56998853-1ce82180-6bad-11e9-9c1c-55f47ac87bab.png">
