### PR TITLE
Fix general dependencies issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Site estático gerado via [Jigsaw](http://jigsaw.tighten.co);
 ## Desenvolvimento do website local
 Requisitos: PHP7.2 e NPM instalados localmente;
 Passos:
-* Instalar jigsaw globalmente (TODO: Tentar mudar para não precisar ser global):
-* > $ composer global require tightenco/jigsaw
 * Fazer fork do repositório;
 * Rodar composer install:
 * > $ composer install

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "herdphp/phpsp.org.br",
   "require": {
+    "php": ">=7.2",
     "tightenco/jigsaw": "^v1.3.6"
   },
   "autoload": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4393,6 +4393,18 @@
                 }
             }
         },
+        "extra-watch-webpack-plugin": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/extra-watch-webpack-plugin/-/extra-watch-webpack-plugin-1.0.3.tgz",
+            "integrity": "sha512-ZScQdMH6hNofRRN6QMQFg+aa5vqimfBgnPXmRDhdaLpttT6hrzpY9Oyren3Gh/FySPrgsvKCNbx/NFA7XNdIsg==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.2",
+                "is-glob": "^4.0.0",
+                "lodash.uniq": "^4.5.0",
+                "schema-utils": "^0.4.0"
+            }
+        },
         "extract-text-webpack-plugin": {
             "version": "4.0.0-beta.0",
             "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-4.0.0-beta.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "sass": "^1.17.0",
         "sass-loader": "7.*",
         "vue-template-compiler": "2.6.2",
-        "webpack-watch": "^0.2.0",
+        "extra-watch-webpack-plugin": "^1.0.3",
         "yargs": "^4.6.0"
     },
     "dependencies": {

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -5,7 +5,7 @@ let command = require('node-cmd');
 let AfterWebpack = require('on-build-webpack');
 let BrowserSync = require('browser-sync');
 let BrowserSyncPlugin = require('browser-sync-webpack-plugin');
-let Watch = require('webpack-watch');
+let ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 
 let browserSyncInstance;
 let env = argv.e || argv.env || 'local';
@@ -23,9 +23,8 @@ module.exports = {
     }),
 
     watch: function(paths) {
-        return new Watch({
-            options: { ignoreInitial: true },
-            paths: paths,
+        return new ExtraWatchWebpackPlugin({
+            files: paths,
         })
     },
 


### PR DESCRIPTION
Este pull request:

- Troca o pacote `webpack-watch` por `extra-watch-webpack-plugin`
- Torna PHP `7.2` ou superior como dependência no composer.json
- Remove instrução sobre instância global do Jigsaw no readme.md, corrigida anteriormente

A troca do pacote `webpack-watch` é necessária pois o atual `npm run watch` quebra a execução ao iniciar uma segunda instância do webpack. Veja screenshots:

<img width="1280" alt="Screenshot 2019-05-01 at 01 32 49" src="https://user-images.githubusercontent.com/3905582/57000015-098b8500-6bb2-11e9-9434-ce31e20e8127.png">
<img width="1280" alt="Screenshot 2019-05-01 at 01 33 15" src="https://user-images.githubusercontent.com/3905582/57000016-098b8500-6bb2-11e9-8565-7bca29f90b1a.png">
