### PR TITLE
Fixes fake horizontal scrolling

### DIFF
--- a/source/_assets/sass/breadcrumb/main.scss
+++ b/source/_assets/sass/breadcrumb/main.scss
@@ -1,0 +1,3 @@
+.breadcrumb ul li {
+  white-space: normal;
+}

--- a/source/_assets/sass/main.scss
+++ b/source/_assets/sass/main.scss
@@ -1,4 +1,5 @@
 @import './node_modules/bulma/bulma.sass';
+@import 'breadcrumb/main';
 
 .is-white-space-normal {
   white-space: normal !important;


### PR DESCRIPTION
A implementação atual utiliza o framework Bulma para estilos CSS. Este framework não está preparado para lidar com itens tão longos no Breadcrumb.

Como efeito desta falha, o menu fica inacessível para dispositivos móveis e cria um scrolling horizontal indesejável.

Este pull request força a quebra de texto para próxima linha quando necessário no breadcrumb.

<img width="1184" alt="Screenshot 2019-05-01 at 02 10 53" src="https://user-images.githubusercontent.com/3905582/57000964-6ee17500-6bb6-11e9-82ee-531fd39f7db3.png">
<img width="1146" alt="Screenshot 2019-05-01 at 02 11 16" src="https://user-images.githubusercontent.com/3905582/57000965-6ee17500-6bb6-11e9-808e-70947c72f37b.png">
