### PR TITLE
[Issue #23] Fixes sponsors list at home-page

### DIFF
--- a/source/_partials/layout/sponsors.blade.php
+++ b/source/_partials/layout/sponsors.blade.php
@@ -1,5 +1,6 @@
+@foreach($page->sponsors->chunk(4) as $sponsors)
 <div class="level is-small">
-    @foreach( $page->sponsors as $sponsor)
+    @foreach($sponsors as $sponsor)
         <div class="level-item">
             <a href="{{ $sponsor->url }}" target="_blank">
                 <figure class="image is-128x128">
@@ -10,3 +11,4 @@
         </div>
     @endforeach
 </div>
+@endforeach


### PR DESCRIPTION
Este pull request agrupa a lista de patrocinadores de 4 em 4 e faz com que um novo elemento `level` seja criado a cada agrupamento.

Desta forma ao acessar o site em dispositivos com `width >= 769px` a lista de patrocinadores será quebrada em mais de uma linha, corrigindo o bug de overflow apontado na issue #23.