### PR TITLE
Removes branch information as it is no longer necessary

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,6 +1,5 @@
 | Q             | A
 | ------------- | ---
-| Branch?       | master para conteúdos; develop para funcionalidades;
 | Bug fix?      | sim/não
 | Nova feature?  | sim/não
 | Conteúdo?  | sim/não <!-- Responder as perguntas abaixo caso seja conteúdo -->

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Passos:
 * > $ npm install
 * Reixar o NPM "observando" as mudanças (e gerando o conteúdo estático):
 * > $ npm run watch
-* Enviar um PR para `develop` com as alterações;
+* Enviar um PR para `master` com as alterações;


### PR DESCRIPTION
Recentemente removemos o branch `develop` para destravar o desenvolvimento do projeto. Este PR remove a necessidade de apontar o branch no template de Pull Request para evitar confusão.