### PR TITLE
corrigindo o link para listagem de artigos na pagina principal

### DIFF
--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -26,7 +26,7 @@ pagination:
             </div>
             <div class="column">
                 <h2 class="title is-2">
-                    <a class="has-text-grey-dark" href="{{ $page->getUrl() }}blog">Artigos</a>
+                    <a class="has-text-grey-dark" href="{{ $page->getUrl() }}artigos">Artigos</a>
                 </h2>
                 @include('_partials.content.posts.list')
             </div>


### PR DESCRIPTION
Na página inicial, ao clicar no link "Artigos" acima do grid-item que listam os artigos mais recentes, estava levando para url /blog que não existe, alterei para levar para /artigos que é onde de fato está a listagem completa dos artigos