### PR TITLE
Setup docker for development and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/php:7.2-node-browsers
+      - image: circleci/buildpack-deps
 
     steps:
       - checkout
@@ -12,7 +12,7 @@ jobs:
             - v1-dependencies-{{ checksum "composer.json" }}
             - v1-dependencies-
 
-      - run: composer install --no-interaction --no-progress
+      - run: docker-compose run --rm -T web composer install --no-interaction --no-progress
 
       - save_cache:
           key: v1-dependencies-{{ checksum "composer.json" }}
@@ -23,10 +23,10 @@ jobs:
           keys:
             - node-v1-{{ checksum "package.json" }}
             - node-v1-
-      - run: yarn install
+      - run: docker-compose run --rm -T web yarn install
       - save_cache:
           key: node-v1-{{ checksum "package.json" }}
           paths:
             - node_modules
 
-      - run: yarn production
+      - run: docker-compose run --rm -T web yarn production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
             - v1-dependencies-{{ checksum "composer.json" }}
             - v1-dependencies-
 
+      - run: docker-compose build --build-arg UID=$(id -u) --build-arg GID=$(id -g) web
       - run: docker-compose run --rm -T web composer install --no-interaction --no-progress
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,7 @@
 version: 2
 jobs:
   build:
-    docker:
-      - image: circleci/buildpack-deps
-    working_directory: /var/app
+    machine: true
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/buildpack-deps
+    working_directory: /var/app
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
 
     steps:
       - checkout
+      - setup_remote_docker
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
 
     steps:
       - checkout
-      - setup_remote_docker
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -23,19 +23,26 @@ do nosso Slack.
 * Enviar um PR para `master` com o novo conteúdo;
 
 ## Desenvolvimento do website local
-Requisitos: PHP7.2 e Yarn instalados localmente;
+Requisitos: Docker e Docker-compose instalados localmente;
+
 Passos:
 * Fazer fork do repositório;
+* Fazer o `build` do container do docker:
+```sh
+docker-compose build
+```
 * Rodar composer install:
 ```sh
-composer install
+docker-compose run --rm web composer install
 ```
 * Rodar yarn install:
 ```sh
-yarn install
+docker-compose run --rm web yarn install
 ```
 * Deixar o yarn "observando" as mudanças (e gerando o conteúdo estático):
 ```sh
-yarn watch
+docker-compose up
 ```
-* Enviar um PR para `master` com as alterações;
+* Abrir a URL http://localhost:3000/ e ver o site rodando :)
+
+* Após fazer suas alterações, enviar um PR para `master` com as alterações;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.2"
+
+services:
+  web:
+    build: docker/web
+    volumes:
+      - .:/var/app
+    ports:
+      - "3000:3000"
+    command: yarn watch

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -23,6 +23,7 @@ RUN groupmod -g ${GID} www-data \
   && usermod -u ${UID} -g www-data www-data \
   && mkdir -p /var/app \
   && chown -hR www-data:www-data \
+    /var/www \
     /var/app \
     /usr/local/
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,0 +1,33 @@
+FROM php:7.2-stretch
+
+# Start Node.js installation
+COPY --from=node:stretch /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:stretch "/opt/yarn-v*" /opt/yarn
+
+RUN ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg
+
+ENV PATH="$(yarn global bin):$PATH"
+# End Node.js Installation
+
+# Start Composer installation
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+# End Composer installation
+
+# Start creation pf non-root user
+ARG UID=1000
+ARG GID=1000
+
+RUN groupmod -g ${GID} www-data \
+  && usermod -u ${UID} -g www-data www-data \
+  && mkdir -p /var/app \
+  && chown -hR www-data:www-data \
+    /var/app \
+    /usr/local/
+
+USER www-data:www-data
+# End creation of non-root user
+
+WORKDIR /var/app
+EXPOSE 3000

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -31,6 +31,7 @@ module.exports = {
     browserSync: function(proxy) {
         return new BrowserSyncPlugin({
             notify: false,
+            open: false,
             port: port,
             proxy: proxy,
             server: proxy ? null : { baseDir: 'build_' + env + '/' },


### PR DESCRIPTION
Agora não precisamos mais das dependências na máquina, dá pra rodar tudo de dentro do docker :wink:

A única mudança (tirando os comandos em si) é que rodar os scripts de `dev` e `watch` não abrem mais o browser porque tá dentro do docker. Não sei se teria como resolver mas nem fui atrás porque não julguei muito importante. Se acharem que é must para entregar, eu vejo se tem o que fazer.

Fixes #48.