### PR TITLE
Adiciona um sitemap.xml ao projeto

### DIFF
--- a/app/Site/EventHandlers/AfterBuild/GenerateSitemap.php
+++ b/app/Site/EventHandlers/AfterBuild/GenerateSitemap.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Phpsp\Site\EventHandlers\AfterBuild;
+
+use Phpsp\Site\EventHandlers\JigsawHandlerInterface;
+use PODEntender\SitemapGenerator\Adapter\Jigsaw\JigsawAdapter;
+use TightenCo\Jigsaw\Jigsaw;
+
+class GenerateSitemap implements JigsawHandlerInterface
+{
+    const SITEMAP_FILENAME = 'sitemap.xml';
+
+    public function handle(Jigsaw $jigsaw): void
+    {
+        $output = $jigsaw->getDestinationPath() . DIRECTORY_SEPARATOR . self::SITEMAP_FILENAME;
+
+        /** @var JigsawAdapter $generator */
+        $generator = $jigsaw->app->make(JigsawAdapter::class);
+
+        $xmlSitemap = $generator->fromCollection($jigsaw->getCollection('posts'));
+
+        file_put_contents($output, $xmlSitemap->saveXML());
+    }
+}

--- a/app/Site/EventHandlers/JigsawHandlerInterface.php
+++ b/app/Site/EventHandlers/JigsawHandlerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Phpsp\Site\EventHandlers;
+
+use TightenCo\Jigsaw\Jigsaw;
+
+interface JigsawHandlerInterface
+{
+    public function handle(Jigsaw $jigsaw): void;
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-use TightenCo\Jigsaw\Jigsaw;
+use Phpsp\Site\EventHandlers\AfterBuild\GenerateSitemap;
 use Mni\FrontYAML\Markdown\MarkdownParser as BaseParser;
 use Phpsp\Site\Parsers\MarkdownParser;
 use Phpsp\Site\Parsers\Parsedown;
@@ -23,3 +23,7 @@ $container->bind(BaseParser::class, MarkdownParser::class);
 $container->bind(Parsedown::class, function ($app) {
     return new Parsedown($app->config['baseUrl']);
 });
+
+$events->afterBuild([
+    GenerateSitemap::class,
+]);

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
   "require": {
     "php": ">=7.2",
     "tightenco/jigsaw": "^v1.3.8",
-    "mnapoli/front-yaml": "^1.6.0"
+    "mnapoli/front-yaml": "^1.6.0",
+    "podentender/sitemap-generator": "^0.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "551b6ec08a09ca199690b7f28a76bd04",
+    "content-hash": "35ac3bf7066cc2643e7c48375eaf6a0d",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -716,6 +716,54 @@
                 "type"
             ],
             "time": "2015-07-25T16:39:46+00:00"
+        },
+        {
+            "name": "podentender/sitemap-generator",
+            "version": "0.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PODEntender/sitemap-generator.git",
+                "reference": "70ccfd1071562b0cd272858b757eb9a83dc1ba87"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PODEntender/sitemap-generator/zipball/70ccfd1071562b0cd272858b757eb9a83dc1ba87",
+                "reference": "70ccfd1071562b0cd272858b757eb9a83dc1ba87",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.1",
+                "tightenco/jigsaw": "^1.3"
+            },
+            "suggest": {
+                "tightenco/jigsaw": "Allows using the PODEntender\\SitemapGenerator\\Adapter\\JigsawAdapter"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PODEntender\\SitemapGenerator\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "PODEntender",
+                    "email": "tech@podentender.com"
+                },
+                {
+                    "name": "Níckolas Da Silva",
+                    "email": "nickolas@phpsp.org.br"
+                }
+            ],
+            "description": "A general purpose sitemap generator package for dynamic or static websites",
+            "time": "2019-07-03T17:46:21+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
**Efeitos positivos:**
Após aprovado, a build irá gerar um arquivo `sitemap.xml` na raiz do projeto. Este arquivo segue os padrões definidos no site [sitemaps.org](https://www.sitemaps.org).

Com este arquivo em mãos, poderemos submeter a mecanismos de busca como `Google`, `Bing`, `Yahoo` e assim facilitar que estes mecanismos de busca saibam sobre posts novos num espaço curto de tempo, indexando nossas páginas mais facilmente.

**Este pull request:**

- Adiciona `podentender/sitemap-generator` como dependência
- Adiciona um evento em `afterBuild()` no `bootstrap.php`
- Adiciona o namespace `EventHandlers`

**Limitações:**

- O pacote `podentender/sitemap-generator` por enquanto só suporta trabalhar com Collections. Páginas como home, faq e demais estão indisponíveis no sitemap.
- Tags como `<lastmod>`, `<changefreq>` e `<priority>` não estão ainda implementadas no pacote `podentender/sitemap-generator`. Em breve será adicionado suporte a callbacks e então poderemos adicionar aqui
