### PR TITLE
Add link[rel=canonical] to head.blade.php partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,27 @@ do nosso Slack.
     Lorem ipsum
 * Enviar um PR para `master` com o novo conteúdo;
 
+## Convenções e metadados em arquivos markdown
+
+Todo post em `.md` contém algumas convenções e metadados que você pode aproveitar enquanto escreve seu artigo:
+
+* Gravatar
+
+Através do metadado `authorEmail` iremos procurar um avatar disponível no site [Gravatar](https://gravatar.com) para exibição.
+
+* Canonical
+
+Se por qualquer motivo (um re-post, por exemplo) você desejar alterar a url canônica do seu post, você pode utilizar o metadado
+`canonicalHref` apontando para a url original. Veja o exemplo abaixo:
+
+```markdown
+---
+createdAt: 2019-05-12
+...
+canonicalHref: 'https://meublog.com.br/post-original'
+---
+```
+
 ## Desenvolvimento do website local
 Requisitos: Docker e Docker-compose instalados localmente;
 

--- a/source/_partials/layout/head.blade.php
+++ b/source/_partials/layout/head.blade.php
@@ -2,6 +2,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <link rel="canonical" href="{{ $page->canonicalHref ?? $page->getUrl() }}" />
     <title>PHPSP | {{$page->title}}</title>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
Este pull request:

- Altera a partial `head.blade.php` para adicionar o link[rel=canonical]
- O valor padrão deste element é `$page->getUrl()`
- O valor pode ser sobrescrito em qualquer post ao adicionar o meta dado `canonicalHref`

Exemplo de sobrescrita em um post:
```markdown
---
createdAt: 2019-05-12
title: '5 bons motivos para NÃO usar arrays no PHP 7.4'
author: Níckolas Silva
authorEmail: nawarian@gmail.com
canonicalHref: 'https://umsite.com.br/motivos-coisados'
---
```