### PR TITLE
Corrige canonical href pra apontar para o site do phpsp.org.br

### DIFF
--- a/source/_posts/5-bons-motivos-para-NÃO-usar-arrays-no-php-74.md
+++ b/source/_posts/5-bons-motivos-para-NÃO-usar-arrays-no-php-74.md
@@ -3,7 +3,6 @@ createdAt: 2019-05-12
 title: '5 bons motivos para NÃO usar arrays no PHP 7.4'
 author: Níckolas Silva
 authorEmail: nickolas@nawarian.xyz
-canonicalHref: 'https://imasters.com.br/back-end/5-bons-motivos-para-nao-usar-arrays-no-php-7-4'
 ---
 
 A versão do php que ainda está por vir, a `7.4`, está cada vez mais rapidamente tomando forma e até o presente momento


### PR DESCRIPTION
Este post foi desenvolvido originalmente para o site phpsp.org.br, não
há motivos para enviar o canonical para o site do imasters. O href atual
diminui o tráfego do site phpsp.org.br e direciona ao imasters sem nenhum
motivo aparente.