### PR TITLE
issue #49 Adiciona imagem php 7.4-apache

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-stretch
+FROM php:7.4-apache
 
 # Start Node.js installation
 COPY --from=node:stretch /usr/local/bin/node /usr/local/bin/node


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | não
| Nova feature?  | não
| Conteúdo?  | não 
| Precisa de revisão? | **sim**

Foi alterada a imagem docker do php 7.2 para 7.4, estou criando o PR pra ver se algum build quebra.
Executei o build local e foi tudo certo...
Uma pergunta: era usado o `7.2-stretch` e nao tem esse cara pro 7.4, entao usei o `7.4-apache`, ha algum problema?
Caso precise executar mais algumas coisas pra garantir a migracao deem um toque que eu farei aqui