### PR TITLE
Criando índice lateral nos artigos

### DIFF
--- a/app/Site/EventHandlers/AfterCollections/GenerateToC.php
+++ b/app/Site/EventHandlers/AfterCollections/GenerateToC.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Phpsp\Site\EventHandlers\AfterCollections;
+
+use DOMDocument;
+use DOMElement;
+use DOMXpath;
+use Phpsp\Site\EventHandlers\AfterCollections\ToC\Header;
+use Phpsp\Site\EventHandlers\JigsawHandlerInterface;
+use TightenCo\Jigsaw\Collection\CollectionItem;
+use TightenCo\Jigsaw\Jigsaw;
+
+class GenerateToC implements JigsawHandlerInterface
+{
+    /**
+     * @var int $minItemsToDisplay Número mínimo de itens para que o índice seja exibido
+     */
+    private $minItemsToDisplay;
+
+    /**
+     * @var int $maxItemsToDisplay Número máximo de itens a serem exibidos no índice
+     */
+    private $maxItemsToDisplay;
+
+    private $xpath;
+
+    /**
+     * @param int $minItemsToDisplay Número mínimo de itens para que o índice seja exibido
+     * @param int $maxItemsToDisplay Número máximo de itens a serem exibidos no índice
+     * @param int $minLevel Nível de cabeçalho mínimo a ser exibido
+     * @param int $maxLevel Nível de cabeçalho máximo a ser exibido
+     */
+    public function __construct(int $minItemsToDisplay, int $maxItemsToDisplay, int $minLevel, int $maxLevel)
+    {
+        $this->minItemsToDisplay = $minItemsToDisplay;
+        $this->maxItemsToDisplay = $maxItemsToDisplay;
+        $this->xpath = '//h' . \implode(' | //h', \range($minLevel, $maxLevel));
+    }
+
+    public function handle(Jigsaw $jigsaw): void
+    {
+        /** @var \TightenCo\Jigsaw\Collection\CollectionItem $item */
+        $collection = $jigsaw->getCollection('posts');
+        foreach ($collection as $item) {
+            $this->runItem($item);
+        }
+    }
+
+    private function runItem(CollectionItem $item): void
+    {
+        $html = $item->getContent();
+        if (empty($html)) {
+            return;
+        }
+
+        $oldValue = \libxml_use_internal_errors(true);
+        $dom = new DOMDocument('1.0', 'utf-8');
+        $dom->loadHTML('<?xml encoding="UTF-8">' . $html);
+        \libxml_use_internal_errors($oldValue);
+
+        $xpath = new DOMXpath($dom);
+        $nodes = $xpath->query($this->xpath);
+        if ($nodes === false) {
+            return;
+        }
+        $nodes = \iterator_to_array($nodes);
+        $count = \count($nodes);
+
+        if ($count < $this->minItemsToDisplay) {
+            return;
+        }
+
+        if ($count >= $this->maxItemsToDisplay) {
+            $nodes = $this->pruneHeaders($nodes, $this->maxItemsToDisplay);
+        }
+
+        $toc = $this->buildTableOfContents($nodes);
+        if ($toc->hasChildren()) {
+            $item->set('tableOfContents', $toc);
+        }
+    }
+
+    private function buildTableOfContents(array $nodes): Header
+    {
+        $root = new Header(0, 'Root', null);
+        $lastElement = $root;
+
+        /** @var DOMElement $node */
+        foreach ($nodes as $node) {
+            /** @var DOMElement $span */
+            foreach ($node->childNodes as $span) {
+                if (\strtolower($span->tagName) === 'span') {
+                    $header = new Header(
+                        (int) substr($node->tagName, 1),
+                        $span->textContent,
+                        $node->getAttribute('id')
+                    );
+
+                    $parent = $this->getParentFor($header, $lastElement);
+                    if (!$parent) {
+                        $parent = $root;
+                    }
+
+                    $parent->addChild($header);
+                    $lastElement = $header;
+
+                    break;
+                }
+            }
+        }
+
+        return $root;
+    }
+
+    /**
+     * Retorna o elemento que deve ser o pai deste cabeçalho
+     * @param Header $header
+     * @param Header $lastElement
+     * @return Header|null
+     */
+    private function getParentFor(Header $header, Header $lastElement): ?Header
+    {
+        $level = $header->getLevel();
+        $lastLevel = $lastElement->getLevel();
+
+        // Adiciona como filho do último elemento (ex: h2 depois de um h1)
+        if ($level > $lastLevel) {
+            return $lastElement;
+        }
+
+        // Adiciona ao pai (ex: h2 depois de vários h3)
+        // É preciso fazer recursivamente os níveis caso alguém coloque um h2 depois de vários h4, por exemplo
+        if ($level < $lastLevel) {
+            $parent = $lastElement;
+            for ($i = $level; $i <= $lastLevel; ++$i) {
+                $parent = $parent->getParent();
+                if (!$parent) {
+                    break;
+                }
+            }
+            return $parent;
+        }
+
+        // Se for no mesmo nível, então é um "irmão" do último cabeçalho
+        return $lastElement->getParent();
+    }
+
+    /**
+     * Remove cabeçalhos até que tenhamos $maxTocNodes
+     * @param array $nodes
+     * @param int $maxTocNodes
+     * @return DOMElement[]
+     */
+    private function pruneHeaders(array $nodes, int $maxTocNodes): array
+    {
+        $count = \count($nodes);
+        for ($levelToRemove = 6; $levelToRemove > 2; $levelToRemove--) {
+            foreach ($nodes as $key => $header) {
+                $level = (int) substr($header->tagName, 1);
+                if ($level === $levelToRemove) {
+                    unset($nodes[$key]);
+                    if (--$count < $maxTocNodes) {
+                        break;
+                    }
+                }
+            }
+        }
+        return $nodes;
+    }
+}

--- a/app/Site/EventHandlers/AfterCollections/ToC/Header.php
+++ b/app/Site/EventHandlers/AfterCollections/ToC/Header.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Phpsp\Site\EventHandlers\AfterCollections\ToC;
+
+class Header
+{
+    /**
+     * @var int
+     */
+    private $level;
+
+    /**
+     * @var string
+     */
+    private $text;
+
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var Header|null
+     */
+    private $parent = null;
+
+    /**
+     * @var Header[]
+     */
+    private $children = [];
+
+    public function __construct(int $level, string $text, string $url = null)
+    {
+        $this->level = $level;
+        $this->text = $text;
+        $this->url = $url ?? '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @return Header|null
+     */
+    public function getParent(): ?Header
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @param Header|null $parent
+     * @return $this
+     */
+    public function setParent(?Header $parent): self
+    {
+        $this->parent = $parent;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasChildren(): bool
+    {
+        return !empty($this->children);
+    }
+
+    /**
+     * @return array
+     */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    /**
+     * @param Header $child
+     * @return $this
+     */
+    public function addChild(Header $child): self
+    {
+        $child->setParent($this);
+        $this->children[] = $child;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -3,8 +3,10 @@
 use Phpsp\Site\EventHandlers\AfterBuild\GenerateSitemap;
 use Phpsp\Site\EventHandlers\AfterBuild\GenerateRssFeed;
 use Mni\FrontYAML\Markdown\MarkdownParser as BaseParser;
+use Phpsp\Site\EventHandlers\AfterCollections\GenerateToC;
 use Phpsp\Site\Parsers\MarkdownParser;
 use Phpsp\Site\Parsers\Parsedown;
+use TightenCo\Jigsaw\Jigsaw;
 
 /** @var $container \Illuminate\Container\Container */
 /** @var $events \TightenCo\Jigsaw\Events\EventBus */
@@ -24,8 +26,20 @@ $container->bind(BaseParser::class, MarkdownParser::class);
 $container->bind(Parsedown::class, function ($app) {
     return new Parsedown($app->config['baseUrl']);
 });
+$container->bind(GenerateToC::class, function ($app) {
+    return new GenerateToC(
+        $app->config['toc']['min_items_to_display'],
+        $app->config['toc']['max_items_to_display'],
+        $app->config['toc']['min_heading_level'],
+        $app->config['toc']['max_heading_level'],
+    );
+});
 
 $events->afterBuild([
     GenerateSitemap::class,
     GenerateRssFeed::class,
 ]);
+
+$events->afterCollections(function (Jigsaw $jigsaw) use ($container) {
+    $container->get(GenerateToC::class)->handle($jigsaw);
+});

--- a/config.php
+++ b/config.php
@@ -181,9 +181,9 @@ return [
         ],
     ],
     'toc' => [
-        'min_items_to_display' => 5,
+        'min_items_to_display' => 3,
         'max_items_to_display' => 15,
         'min_heading_level' => 1,
-        'max_heading_level' => 4,
+        'max_heading_level' => 3,
     ],
 ];

--- a/config.php
+++ b/config.php
@@ -180,4 +180,10 @@ return [
             'url' => 'https://github.com/PHPSP/zf2-documentation-br',
         ],
     ],
+    'toc' => [
+        'min_items_to_display' => 5,
+        'max_items_to_display' => 15,
+        'min_heading_level' => 1,
+        'max_heading_level' => 4,
+    ],
 ];

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -qq \
   zip \
   unzip \
   libzip-dev \
+  locales \
   && docker-php-ext-install \
   zip \
   && apt-get clean
@@ -41,6 +42,12 @@ RUN groupmod -g ${GID} www-data \
 
 USER www-data:www-data
 # End creation of non-root user
+
+# Start locale configuration
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+  && dpkg-reconfigure --frontend=noninteractive locales \
+  && update-locale LANG=pt_BR.UTF-8
+# End locale configuration
 
 WORKDIR /var/app
 EXPOSE 3000

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -28,6 +28,12 @@ RUN apt-get update -qq \
   && apt-get clean
 # End Project dependencies installation
 
+# Start locale configuration
+RUN sed -i -e 's/# pt_BR.UTF-8 UTF-8/pt_BR.UTF-8 UTF-8/' /etc/locale.gen \
+  && dpkg-reconfigure --frontend=noninteractive locales \
+  && update-locale LANG=pt_BR.UTF-8
+# End locale configuration
+
 # Start creation of non-root user
 ARG UID=1000
 ARG GID=1000
@@ -42,12 +48,6 @@ RUN groupmod -g ${GID} www-data \
 
 USER www-data:www-data
 # End creation of non-root user
-
-# Start locale configuration
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
-  && dpkg-reconfigure --frontend=noninteractive locales \
-  && update-locale LANG=pt_BR.UTF-8
-# End locale configuration
 
 WORKDIR /var/app
 EXPOSE 3000

--- a/source/_assets/js/clipboard.js
+++ b/source/_assets/js/clipboard.js
@@ -1,0 +1,35 @@
+const showError = () => alert('Houve um erro ao copiar endereço para a área de transferências');
+
+// @link https://stackoverflow.com/a/30810322
+function fallbackCopyTextToClipboard(text) {
+    const textArea = document.createElement("textarea");
+    textArea.value = text;
+
+    // Avoid scrolling to bottom
+    textArea.style.top = "0";
+    textArea.style.left = "0";
+    textArea.style.position = "fixed";
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    try {
+        if (!document.execCommand('copy')) {
+            showError();
+        }
+    } catch {
+        showError();
+    }
+
+    document.body.removeChild(textArea);
+}
+
+module.exports = function copyTextToClipboard(text) {
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(function () {
+        }, showError);
+        return;
+    }
+    fallbackCopyTextToClipboard(text);
+}

--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -1,8 +1,17 @@
 import Vue from "vue";
+import copyTextToClipboard from "./clipboard";
 import MeetupEvents from "./components/meetup-events"
-
+import ScrollSpy from "./scrollspy";
 
 const app = new Vue({
     el: "#app",
     components: { MeetupEvents }
+});
+
+window.addEventListener('load', function () {
+    new ScrollSpy(
+        document.getElementById('post-contents'),
+        document.getElementById('toc'),
+        document.getElementById('navbar'),
+    );
 });

--- a/source/_assets/js/scrollspy.js
+++ b/source/_assets/js/scrollspy.js
@@ -1,0 +1,100 @@
+const copyTextToClipboard = require('./clipboard');
+
+class ScrollSpy {
+    constructor($content, $menu, $navbar) {
+        if (!$content instanceof HTMLElement) {
+            throw new Error('Content must be an HTML element');
+        }
+        if (!$menu instanceof HTMLElement) {
+            throw new Error('Menu must be an HTML element');
+        }
+        if (!$navbar instanceof HTMLElement) {
+            throw new Error('Navbar must be an HTML element');
+        }
+
+        const visitedNodes = {},
+            headers = {},
+            $links = $menu.querySelectorAll('a[href]'),
+            $headers = Array.from($content.querySelectorAll('h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]'));
+
+        let oldActiveId,
+            currentActiveId,
+            navbarHeight,
+            headerKeys = {};
+
+        const getNode = (id) => {
+            if (visitedNodes[id] === undefined) {
+                visitedNodes[id] = $menu.querySelector(`a[href="#${id}"]`);
+            }
+            return visitedNodes[id];
+        }
+
+        const onScroll = function () {
+            const SCROLL_TOP = (document.scrollingElement.scrollTop || document.body.scrollTop) + navbarHeight + 20; // some padding
+            for (const id of headerKeys) {
+                if (headers[id] < SCROLL_TOP) {
+                    currentActiveId = id;
+                    break;
+                }
+            }
+
+            if ((currentActiveId) && (currentActiveId !== oldActiveId)) {
+                let node = getNode(currentActiveId);
+                if (!node) {
+                    return;
+                }
+                history.replaceState(null, null, `#${currentActiveId}`);
+                node.classList.add('active');
+                if (oldActiveId) {
+                    let node = getNode(oldActiveId);
+                    if (node) {
+                        node.classList.remove('active');
+                    }
+                }
+                oldActiveId = currentActiveId;
+            }
+        };
+
+        const calculateHeadersOffset = function () {
+            navbarHeight = $navbar.getBoundingClientRect().y;
+            $links.forEach(($link) => {
+                const id = $link.attributes.href.value.substring(1);
+                const $header = $headers.find(h => h.id === id);
+                if ($header) {
+                    headers[id] = $header.offsetTop;
+                }
+            });
+            headerKeys = Object.keys(headers).reverse();
+            onScroll();
+        }
+
+        $links.forEach(($link) => {
+            const id = $link.attributes.href.value.substring(1);
+            const $header = $headers.find(h => h.id === id);
+            if ($header) {
+                $link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    window.scrollTo({
+                        top: $header.offsetTop - navbarHeight,
+                    });
+                });
+            }
+        });
+
+        document.querySelectorAll('a.pilcrow[href]').forEach(
+            (node) => node.addEventListener(
+                'click',
+                (e) => {
+                    e.preventDefault();
+                    copyTextToClipboard(node.href);
+                }
+            )
+        );
+
+        window.addEventListener('scrollend', onScroll);
+        window.addEventListener('resize', calculateHeadersOffset);
+        calculateHeadersOffset();
+    }
+}
+
+module.exports = ScrollSpy;

--- a/source/_assets/sass/main.scss
+++ b/source/_assets/sass/main.scss
@@ -39,3 +39,62 @@ p.warning {
 p.info {
   background-color: #d9edf7;
 }
+
+$base-navbar-height: 3.25rem;
+$navbar-padding-vertical: 1rem;
+$navbar-padding-horizontal: 2rem;
+$navbarHeight: $base-navbar-height;
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: calc($navbarHeight + 10px); // 3.25rem da navbar + 10px gutter
+}
+
+/* Posts */
+#toc > div {
+  position: sticky;
+  top: calc($navbarHeight + 10px);
+  height: calc(100vh - ($navbarHeight + 20px));
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+#toc > .box > ul {
+  margin: 0 -0.5em;
+}
+
+#toc a {
+  color: $grey;
+}
+#toc a:is(:hover, :focus) {
+  color: $grey-dark;
+}
+#toc a.active {
+  color: $grey-darker;
+}
+span.header-span {
+  vertical-align: middle;
+}
+
+a.pilcrow {
+  visibility: hidden;
+  font-size: 0.7em;
+  font-weight: normal;
+  color: $grey-light;
+}
+
+h1:is(:hover, :focus) > a.pilcrow,
+h2:is(:hover, :focus) > a.pilcrow,
+h3:is(:hover, :focus) > a.pilcrow,
+h4:is(:hover, :focus) > a.pilcrow,
+h5:is(:hover, :focus) > a.pilcrow,
+h6:is(:hover, :focus) > a.pilcrow {
+  visibility: visible;
+}
+
+@include desktop {
+  $navbarHeight: $base-navbar-height + 2 * $navbar-padding-vertical;
+  #toc > div {
+    top: calc($navbarHeight + 20px);
+    height: calc(100vh - ($navbarHeight + 40px));
+  }
+}

--- a/source/_layouts/post.blade.php
+++ b/source/_layouts/post.blade.php
@@ -2,15 +2,22 @@
 <html class="has-navbar-fixed-top">
 @include('_partials.layout.head')
 
-<?php $isPost = true; ?>
+<?php
+$isPost = true;
+/** @var \TightenCo\Jigsaw\Collection\CollectionItem $page */
+$hasToC = ($page->get('enableToC', true) !== false) &&
+    ($page->has('tableOfContents')) &&
+    ($page->tableOfContents instanceof \Phpsp\Site\EventHandlers\AfterCollections\ToC\Header) &&
+    ($page->tableOfContents->hasChildren());
+?>
 
 <body>
 <section id="app" class="section">
     <div class="container is-max-desktop">
         @include('_partials.layout.navbar')
         @include('_partials.layout.breadcrumbs')
-        <section class="section">
-            <div class="content">
+        <section class="section columns">
+            <div class="content column {{ ($hasToC) ? 'is-8-tablet is-9-desktop' : 'is-12' }}">
                 <h1 class="title is-1">{{ $page->title }}</h1>
                 <p>
                     <small>
@@ -18,9 +25,20 @@
                         em {{ date('d\/m\/Y', $page->createdAt) }}
                     </small>
                 </p>
-        
-                @yield('post')
+                <article id="post-contents">
+                    @yield('post')
+                </article>
             </div>
+            @if ($hasToC)
+            <aside id="toc" class="column is-4-tablet is-3-desktop is-hidden-mobile">
+                <div class="box has-background-light">
+                    <p class="menu-label">Índice</p>
+                    <ul>
+                        @each('_partials.content.posts.toc', $page->tableOfContents->getChildren(), 'header')
+                    </ul>
+                </div>
+            </aside>
+            @endif
         </section>
         <section class="section">
             <div class="container">

--- a/source/_partials/content/posts/toc.blade.php
+++ b/source/_partials/content/posts/toc.blade.php
@@ -1,0 +1,9 @@
+<?php /** @var \Phpsp\Site\EventHandlers\AfterCollections\ToC\Header $header */ ?>
+<li>
+    <a href="#{{ $header->getUrl() }}" class="is-block px-2 py-1">{{ $header->getText() }}</a>
+    @if ($header->hasChildren())
+    <ul class="ml-3">
+        @each('_partials.content.posts.toc', $header->getChildren(), 'header')
+    </ul>
+    @endif
+</li>


### PR DESCRIPTION
Pessoal, estou escrevendo um artigo relativamente longo sobre Docker e a navegação estava um pouco difícil. Então, criei uma simples navegação lateral com o índice dos cabeçalhos do artigo.

No `config.php` tem algumas configurações:

| Configuração           | Padrão | Descrição                                            |
|------------------------|-------:|------------------------------------------------------|
| `min_items_to_display` |      3 | Quantidade mínima de cabeçalhos para exibir o índice |
| `max_items_to_display` |     15 | Quantidade máxima de cabeçalhos a exibir no índice _(irá começar a remover h4/h3/etc até chegar nesse número)_ |
| `min_heading_level`    |      1 | Qual menor nível de cabeçalhos queremos exibir (1-6) |
| `max_heading_level`    |      3 | Qual maior nível de cabeçalhos queremos exibir (1-6) |

Também é possível desativar o índice para algum post em específico adicionando essa diretiva no cabeçalho da página:

```
enableToC: false
```

Segue uma preview da feature:

https://user-images.githubusercontent.com/1877191/234149463-f78543a0-ab1d-414c-856a-899034b283c4.mp4

PS: aceito sugestões de melhorias principalmente no front! Comecei usando o [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) para mapear as áreas que estavam visíveis mas acabei não encontrando bons valores dos parâmetros para ele e fiz na mão mesmo.